### PR TITLE
Use prop-types package instead of deprecated React.PropTypes import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
-    "radium": "^0.18.1",
+    "prop-types": "^15.5.10",
+    "radium": "^0.19.1",
     "react-motion": "^0.4.7"
   },
   "jest": {

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { spring, TransitionMotion } from 'react-motion';
 import Radium from 'radium'
 

--- a/src/components/ClockWrapper.jsx
+++ b/src/components/ClockWrapper.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Radium from 'radium'
 
 import Clock from './Clock'

--- a/src/components/Time.jsx
+++ b/src/components/Time.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Radium from 'radium'
 
 import TimeDropdown from './TimeDropdown'

--- a/src/components/TimeDropdown.jsx
+++ b/src/components/TimeDropdown.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Radium from 'radium'
 import { fadeIn } from '../helpers/animations';
 import { getScrollBarWidth } from '../helpers/dom'

--- a/src/components/Timepicker.jsx
+++ b/src/components/Timepicker.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import debounce from 'lodash/debounce'
 import Radium, { StyleRoot } from 'radium'
 


### PR DESCRIPTION
This PR addresses a run-time warning when rendering the Timepicker widget:

```
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```

I've also updated Radium to v0.19.1 to capture their prop-types package fix as well. Relevant Radium PR: https://github.com/FormidableLabs/radium/pull/898. This change was first introduced into Radium v0.18.3 though they later reverted it and did a major version bump to 0.19.x instead for it.

Specs are passing, and all examples on the demo page seems to work and look the same as before during a manual test.

Resolves issue: https://github.com/patferguson/scheduler-for-toggl/issues/2

Thanks for creating this widget! I've been looking around for a good Android clock-style time picker for a while now. 🙂