### PR TITLE
Fixed bugs, added simple feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ config={{
 	TIMEPICKER_BACKGROUND: 'red',
 	FONT_FAMILY: '"Open Sans", sans-serif'
 }}
+
+//set minutes to span to 5 minute intervals
+config={{
+	useCourseMinutes: true
+}}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ config={{
 
 //set minutes to span to 5 minute intervals
 config={{
-	useCourseMinutes: true
+	useCoarseMinutes: true
 }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Pass a function to be called when time is changed. Used to store time state in p
 ```
 
 
-#### `onDoneClick` (function)
-Displays the "Done" button and calls function when button is clicked. Useful for triggering some action on the parent component, like closing the timepicker
+#### `onDoneClick` (function: `newTime` , `?event`)
+Displays the "Done" button and calls function when button is clicked. Useful for triggering some action on the parent component, like closing the timepicker. Called with update time and event (if button is clicked).
 
 #### `switchToMinuteOnHourSelect` (bool)
 Changes clock unit from hour to minute after selecting an hour. Exists mainly to provides a better user experience.

--- a/docs/js/api.jsx
+++ b/docs/js/api.jsx
@@ -78,7 +78,7 @@ class Installation extends React.Component {
 						{/* ----- */}
 						<h3>
 							<code className="name">onDoneClick</code>&nbsp;
-							accepts <span className="accepts">func</span>&nbsp;
+							accepts <span className="accepts">func</span> (<code className="default">newTime</code>, <code className="default">?event</code>) &nbsp;
 							(default: <code className="default">null</code>)
 						 </h3>
 						<div className="api__description">

--- a/docs/js/examples.jsx
+++ b/docs/js/examples.jsx
@@ -9,6 +9,7 @@ class Installation extends React.Component {
 			example2Time: '6:50 am',
 			example2TimeDisplay: true,
 			example3Time: '2:50',
+			example4Time: '2:50',
 		}
 
 		this.updateDemoTime = this.updateDemoTime.bind(this)
@@ -137,7 +138,7 @@ class YourComponent extends React.Component {
 					<div className="examples__example-3">
 						<div className="examples__example-3-timekeeper-wrapper">
 							<TimeKeeper
-								time={this.state.example1Time}
+								time={this.state.example3Time}
 								onChange={data => this.updateDemoTime(3, data)}
 								config={{
 									TIMEPICKER_BACKGROUND: 'white',
@@ -175,6 +176,49 @@ class YourComponent extends React.Component {
 						DONE_BUTTON_BORDER_COLOR: '#ededed'
 					}}
 					onDoneClick={() => {}}
+				/>;
+			</div>
+		)
+	}
+} </code></pre>
+
+					{/* ----- */}
+					<p className="text">Snap to 5 minute increments.</p>
+					<div className="examples__example-3">
+						<div className="examples__example-3-timekeeper-wrapper">
+							<TimeKeeper
+								time={this.state.example4Time}
+								onChange={data => this.updateDemoTime(4, data)}
+								config={{
+									useCourseMinutes: true
+								}}
+							/>
+						</div>
+					</div>
+
+					<pre><code className="javascript">import React from 'react';
+import TimeKeeper from 'react-timekeeper';
+
+class YourComponent extends React.Component {
+	constructor(props){
+		super(props)
+		this.state = {
+			time: '2:50 pm'
+		}
+		this.handleTimeChange = this.handleTimeChange.bind(this)
+	}
+	handleTimeChange(newTime){
+		this.setState({ time: newTime.formatted})
+	}
+	render(){
+		return (
+			<div>
+				<TimeKeeper
+					time={this.state.time}
+					onChange={this.handleTimeChange}
+					config={{
+						useCourseMinutes: true
+					}}
 				/>;
 			</div>
 		)

--- a/docs/js/examples.jsx
+++ b/docs/js/examples.jsx
@@ -190,7 +190,7 @@ class YourComponent extends React.Component {
 								time={this.state.example4Time}
 								onChange={data => this.updateDemoTime(4, data)}
 								config={{
-									useCourseMinutes: true
+									useCoarseMinutes: true
 								}}
 							/>
 						</div>
@@ -217,7 +217,7 @@ class YourComponent extends React.Component {
 					time={this.state.time}
 					onChange={this.handleTimeChange}
 					config={{
-						useCourseMinutes: true
+						useCoarseMinutes: true
 					}}
 				/>;
 			</div>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:update-snapshots": "npm run test -- -u",
     "dev": "node ./bin/docs-dev.js",
     "build": "NODE_ENV=production node ./bin/docs-build.js",
-    "lib": "rm -rf lib && mkdir lib && babel src --ignore __tests__/ -d lib"
+    "lib": "rm -rf lib && mkdir lib && babel src --ignore __tests__/ -d lib",
+    "libwin": "rimraf lib && mkdir lib && babel src --ignore __tests__/ -d lib"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
@@ -53,6 +54,7 @@
     "react-dom": "^15.4.2",
     "react-hot-loader": "^1.3.1",
     "react-test-renderer": "^15.4.2",
+    "rimraf": "^2.6.3",
     "sass-loader": "^4.1.1",
     "style-loader": "^0.13.1",
     "webpack": "^1.14.0",

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -219,7 +219,7 @@ export class Clock extends React.Component {
 	}
 	mousedrag(e){
 		const { offsetX, offsetY } = calcOffset(this.clock, e.clientX, e.clientY)
-		this.handlePoint(offsetX, offsetY)
+		this.handlePoint(offsetX, offsetY, false, this.dragCount < 2)
 		this.dragCount++
 
 		e.preventDefault()
@@ -241,7 +241,7 @@ export class Clock extends React.Component {
 	touchdrag(e){
 		const touch = e.targetTouches[0];
 		const { offsetX, offsetY } = calcOffset(this.clock, touch.clientX, touch.clientY)
-		this.handlePoint(offsetX, offsetY)
+		this.handlePoint(offsetX, offsetY, false, this.dragCount < 2)
 		this.dragCount++
 
 		e.preventDefault()

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -37,6 +37,8 @@ function deg(rad){
 	return rad * (180 / pi)
 }
 
+let wasDrag = false
+let dragCount = 0
 
 export class Clock extends React.Component {
 	constructor(props){
@@ -182,9 +184,9 @@ export class Clock extends React.Component {
 		)
 	}
 	
-	handlePoint(clientX, clientY, canChangeUnit){
+	handlePoint(clientX, clientY, canChangeUnit, forceCourse){
 
-		const isCourse = this.props.config.useCourseMinutes;
+		const isCourse = this.props.config.useCourseMinutes || forceCourse;
 		const x = clientX - CLOCK_RADIUS
 		const y = -clientY + CLOCK_RADIUS
 
@@ -205,6 +207,8 @@ export class Clock extends React.Component {
 	}
 
 	mousedown(){
+		this.dragCount = 0
+
 		this.mousedragHandler = this.mousedrag.bind(this)
 		this.stopDragHandler = this.stopDragHandler.bind(this)
 
@@ -216,11 +220,14 @@ export class Clock extends React.Component {
 	mousedrag(e){
 		const { offsetX, offsetY } = calcOffset(this.clock, e.clientX, e.clientY)
 		this.handlePoint(offsetX, offsetY)
+		this.dragCount++
 
 		e.preventDefault()
 		return false
 	}
 	touchstart(){
+		this.dragCount = 0
+
 		// bind handlers
 		this.touchdragHandler = this.touchdrag.bind(this)
 		this.stopDragHandler = this.stopDragHandler.bind(this)
@@ -235,6 +242,7 @@ export class Clock extends React.Component {
 		const touch = e.targetTouches[0];
 		const { offsetX, offsetY } = calcOffset(this.clock, touch.clientX, touch.clientY)
 		this.handlePoint(offsetX, offsetY)
+		this.dragCount++
 
 		e.preventDefault()
 		return false
@@ -252,12 +260,12 @@ export class Clock extends React.Component {
 		const evType = e.type;
 		if (evType === 'mouseup'){
 			const { offsetX, offsetY } = calcOffset(this.clock, e.clientX, e.clientY)
-			this.handlePoint(offsetX, offsetY, true)
+			this.handlePoint(offsetX, offsetY, true, !(this.dragCount > 2))
 		} else if (evType === 'touchcancel' || evType === 'touchend'){
 			const touch = e.targetTouches[0];
 			if (touch){
 				const { offsetX, offsetY } = calcOffset(this.clock, touch.clientX, touch.clientY)
-				this.handlePoint(offsetX, offsetY, true)
+				this.handlePoint(offsetX, offsetY, true, !(this.dragCount > 2))
 			}
 		}
 	}

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -37,8 +37,6 @@ function deg(rad){
 	return rad * (180 / pi)
 }
 
-let dragCount = 0
-
 export class Clock extends React.Component {
 	constructor(props){
 		super(props)
@@ -184,8 +182,6 @@ export class Clock extends React.Component {
 	}
 	
 	handlePoint(clientX, clientY, canChangeUnit, forceCoarse){
-
-		const isCoarse = this.props.config.useCoarseMinutes || forceCoarse;
 		const x = clientX - CLOCK_RADIUS
 		const y = -clientY + CLOCK_RADIUS
 
@@ -195,19 +191,27 @@ export class Clock extends React.Component {
 			d = 360 + d
 		}
 
-		//sometimes touch bleeds into please it shoudln't
+		// ensure touch doesn't bleed outside of clock radius
 		const r = Math.sqrt(x * x + y * y)
 		if (r > CLOCK_RADIUS && this.dragCount < 2){
 			return false;
 		}
 
 		const unit = this.props.unit
-		const selected = Math.round( d / 360 * (CLOCK_DATA[unit].increments / (isCoarse ? CLOCK_DATA[unit].coarseMultipiler : 1)) )
+		const isCoarse = this.props.config.useCoarseMinutes || forceCoarse;
+
+		// calculate value based on current clock increments
+		let selected = Math.round(d / 360 * CLOCK_DATA[unit].increments)
+		if (isCoarse){
+			// if coarse, round up/down
+			const multiplier = CLOCK_DATA[unit].coarseMultiplier;
+			selected = Math.round(selected / multiplier) * multiplier;
+		}
 
 		if (unit === 'hour'){
-			this.props.changeHour(selected * (isCoarse ? CLOCK_DATA[unit].coarseMultipiler : 1), canChangeUnit)
+			this.props.changeHour(selected, canChangeUnit)
 		} else if (unit === 'minute'){
-			this.props.changeMinute(selected * (isCoarse ? CLOCK_DATA[unit].coarseMultipiler : 1), canChangeUnit)
+			this.props.changeMinute(selected, canChangeUnit)
 		}
 
 		return true;
@@ -264,15 +268,19 @@ export class Clock extends React.Component {
 		document.removeEventListener('touchcancel', this.stopDragHandler, false)
 		window.blockMenuHeaderScroll = false
 
+		// if user just clicks/taps a number (drag count < 2), then just assume it's a rough tap
+		// and force a rounded/coarse number (ie: 1, 2, 3, 4 is tapped, assume 0 or 5)
+		const forceCoarse = this.dragCount < 2;
+
 		const evType = e.type;
 		if (evType === 'mouseup'){
 			const { offsetX, offsetY } = calcOffset(this.clock, e.clientX, e.clientY)
-			this.handlePoint(offsetX, offsetY, true, !(this.dragCount > 2))
+			this.handlePoint(offsetX, offsetY, true, forceCoarse)
 		} else if (evType === 'touchcancel' || evType === 'touchend'){
 			const touch = e.targetTouches[0] || e.changedTouches[0]
 			if (touch && this.clock){
 				const { offsetX, offsetY } = calcOffset(this.clock, touch.clientX, touch.clientY)
-				this.handlePoint(offsetX, offsetY, true, !(this.dragCount > 2))
+				this.handlePoint(offsetX, offsetY, true, forceCoarse)
 			}
 		}
 	}

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -183,6 +183,8 @@ export class Clock extends React.Component {
 	}
 	
 	handlePoint(clientX, clientY, canChangeUnit){
+
+		const isCourse = this.props.config.useCourseMinutes;
 		const x = clientX - CLOCK_RADIUS
 		const y = -clientY + CLOCK_RADIUS
 
@@ -193,12 +195,12 @@ export class Clock extends React.Component {
 		}
 
 		const unit = this.props.unit
-		const selected = Math.round( d / 360 * CLOCK_DATA[unit].increments )
+		const selected = Math.round( d / 360 * (CLOCK_DATA[unit].increments / (isCourse ? CLOCK_DATA[unit].courseMultipiler : 1)) )
 
 		if (unit === 'hour'){
-			this.props.changeHour(selected, canChangeUnit)
+			this.props.changeHour(selected * (isCourse ? CLOCK_DATA[unit].courseMultipiler : 1), canChangeUnit)
 		} else if (unit === 'minute'){
-			this.props.changeMinute(selected, canChangeUnit)
+			this.props.changeMinute(selected * (isCourse ? CLOCK_DATA[unit].courseMultipiler : 1), canChangeUnit)
 		}
 	}
 

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -222,6 +222,8 @@ export class Clock extends React.Component {
 		this.handlePoint(offsetX, offsetY, false, this.dragCount < 2)
 		this.dragCount++
 
+		console.log(e)
+
 		e.preventDefault()
 		return false
 	}
@@ -262,7 +264,7 @@ export class Clock extends React.Component {
 			const { offsetX, offsetY } = calcOffset(this.clock, e.clientX, e.clientY)
 			this.handlePoint(offsetX, offsetY, true, !(this.dragCount > 2))
 		} else if (evType === 'touchcancel' || evType === 'touchend'){
-			const touch = e.targetTouches[0];
+			const touch = e.targetTouches[0] || e.changedTouches[0]
 			if (touch){
 				const { offsetX, offsetY } = calcOffset(this.clock, touch.clientX, touch.clientY)
 				this.handlePoint(offsetX, offsetY, true, !(this.dragCount > 2))

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -269,7 +269,6 @@ export class Clock extends React.Component {
 			const { offsetX, offsetY } = calcOffset(this.clock, e.clientX, e.clientY)
 			this.handlePoint(offsetX, offsetY, true, !(this.dragCount > 2))
 		} else if (evType === 'touchcancel' || evType === 'touchend'){
-			//console.log(e)
 			const touch = e.targetTouches[0] || e.changedTouches[0]
 			if (touch && this.clock){
 				const { offsetX, offsetY } = calcOffset(this.clock, touch.clientX, touch.clientY)

--- a/src/components/Clock.jsx
+++ b/src/components/Clock.jsx
@@ -183,9 +183,9 @@ export class Clock extends React.Component {
 		)
 	}
 	
-	handlePoint(clientX, clientY, canChangeUnit, forceCourse){
+	handlePoint(clientX, clientY, canChangeUnit, forceCoarse){
 
-		const isCourse = this.props.config.useCourseMinutes || forceCourse;
+		const isCoarse = this.props.config.useCoarseMinutes || forceCoarse;
 		const x = clientX - CLOCK_RADIUS
 		const y = -clientY + CLOCK_RADIUS
 
@@ -202,12 +202,12 @@ export class Clock extends React.Component {
 		}
 
 		const unit = this.props.unit
-		const selected = Math.round( d / 360 * (CLOCK_DATA[unit].increments / (isCourse ? CLOCK_DATA[unit].courseMultipiler : 1)) )
+		const selected = Math.round( d / 360 * (CLOCK_DATA[unit].increments / (isCoarse ? CLOCK_DATA[unit].coarseMultipiler : 1)) )
 
 		if (unit === 'hour'){
-			this.props.changeHour(selected * (isCourse ? CLOCK_DATA[unit].courseMultipiler : 1), canChangeUnit)
+			this.props.changeHour(selected * (isCoarse ? CLOCK_DATA[unit].coarseMultipiler : 1), canChangeUnit)
 		} else if (unit === 'minute'){
-			this.props.changeMinute(selected * (isCourse ? CLOCK_DATA[unit].courseMultipiler : 1), canChangeUnit)
+			this.props.changeMinute(selected * (isCoarse ? CLOCK_DATA[unit].coarseMultipiler : 1), canChangeUnit)
 		}
 
 		return true;

--- a/src/components/Timepicker.jsx
+++ b/src/components/Timepicker.jsx
@@ -67,7 +67,7 @@ export class Timepicker extends React.Component {
 		if (canChangeUnit && unit === 'hour' && props.switchToMinuteOnHourSelect){
 			this.changeUnit('minute')
 		} else if (canChangeUnit && unit === 'minute' && props.closeOnMinuteSelect){
-			props.onDoneClick && props.onDoneClick()
+			props.onDoneClick && props.onDoneClick(this.getTime())
 		}
 	}
 	handleMeridiemChange(val){
@@ -177,7 +177,7 @@ export class Timepicker extends React.Component {
 					changeMeridiem={this.changeMeridiem}
 				/>
 				
-				{this.props.onDoneClick && <span style={styles.doneButton} onClick={this.props.onDoneClick}>Done</span> }
+				{this.props.onDoneClick && <span style={styles.doneButton} onClick={e=>this.props.onDoneClick(this.getTime(), e)}>Done</span> }
 			</StyleRoot>
 		)
 	}

--- a/src/components/Timepicker.jsx
+++ b/src/components/Timepicker.jsx
@@ -27,6 +27,7 @@ export class Timepicker extends React.Component {
 		this.changeMinute =  this.handleTimeChange.bind(this, 'minute')
 		this.changeUnit =  this.changeUnit.bind(this)
 		this.changeMeridiem = this.handleMeridiemChange.bind(this)
+		this.doneClickWithEvent = this.doneClickWithEvent.bind(this)
 
 		this.timeChangeHandler = null;
 		if (typeof props.onChange === 'function') {
@@ -67,7 +68,7 @@ export class Timepicker extends React.Component {
 		if (canChangeUnit && unit === 'hour' && props.switchToMinuteOnHourSelect){
 			this.changeUnit('minute')
 		} else if (canChangeUnit && unit === 'minute' && props.closeOnMinuteSelect){
-			props.onDoneClick && props.onDoneClick(this.getTime())
+			props.onDoneClick && props.onDoneClick(this.getTime(), null)
 		}
 	}
 	handleMeridiemChange(val){
@@ -76,6 +77,9 @@ export class Timepicker extends React.Component {
 				meridiem: val
 			}, this.timeChangeHandler) // update on parent
 		}
+	}
+	doneClickWithEvent(e){
+		this.props.onDoneClick(this.getTime(), e);
 	}
 
 	changeUnit(newUnit){
@@ -177,7 +181,7 @@ export class Timepicker extends React.Component {
 					changeMeridiem={this.changeMeridiem}
 				/>
 				
-				{this.props.onDoneClick && <span style={styles.doneButton} onClick={e=>this.props.onDoneClick(this.getTime(), e)}>Done</span> }
+				{this.props.onDoneClick && <span style={styles.doneButton} onClick={this.doneClickWithEvent}>Done</span> }
 			</StyleRoot>
 		)
 	}

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -6,12 +6,12 @@ export const CLOCK_DATA = {
 		numbers: hours,
 		dropdownOptions: hours,
 		increments: 12,
-		coarseMultipiler: 1
+		coarseMultiplier: 1
 	},
 	minute: {
 		numbers: ['05', 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, '00'].map(a => a.toString()),
 		dropdownOptions: minutes,
 		increments: 60,
-		coarseMultipiler: 5
+		coarseMultiplier: 5
 	}
 }

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -5,11 +5,13 @@ export const CLOCK_DATA = {
 	hour: {
 		numbers: hours,
 		dropdownOptions: hours,
-		increments: 12
+		increments: 12,
+		courseMultipiler: 1
 	},
 	minute: {
 		numbers: ['05', 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, '00'].map(a => a.toString()),
 		dropdownOptions: minutes,
-		increments: 60
+		increments: 60,
+		courseMultipiler: 5
 	}
 }

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -6,12 +6,12 @@ export const CLOCK_DATA = {
 		numbers: hours,
 		dropdownOptions: hours,
 		increments: 12,
-		courseMultipiler: 1
+		coarseMultipiler: 1
 	},
 	minute: {
 		numbers: ['05', 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, '00'].map(a => a.toString()),
 		dropdownOptions: minutes,
 		increments: 60,
-		courseMultipiler: 5
+		coarseMultipiler: 5
 	}
 }


### PR DESCRIPTION
- Fixed critical event handler leak (new event handlers were added instead of removed) https://github.com/catc/react-timekeeper/issues/18
- Fixed where first tap/click sticks to round 5 minute intervals as requested by in issue https://github.com/catc/react-timekeeper/issues/1
- Added passing time to onDoneClick https://github.com/catc/react-timekeeper/issues/16
- Added config entry `useCoarseMinutes` which snaps to 5 minute intervals
- Fixed a bug in the docs, where example 3 was not updating (pointing at wrong state object)
- Updated docs to show new coarse features

I love this control, Wanted to use it in a framework7-react app I'm throwing together and I had some trouble on iOS with it. This resolves most of my issues.