### PR TITLE
Add new parameter 'hourMode' to choose between am/pm or 24 hour format

### DIFF
--- a/docs/js/installation.jsx
+++ b/docs/js/installation.jsx
@@ -1,27 +1,7 @@
 import React from 'react'
 
 class Installation extends React.Component {
-	constructor(props){
-		super(props)
-		this.state = {
-			// time: '3:70'
-			demoTime: '12:45 pm',
-			displayDemo: true
-		}
-
-		this.updateDemoTime = this.updateDemoTime.bind(this)
-	}
-	updateDemoTime(data){
-		this.setState({ demoTime: data.formatted})
-	}
-	toggleDemoDisplay(val){
-		this.setState({displayDemo: val})
-	}
-
-
 	render(){
-		const state = this.state
-
 		return (
 			<section className="installation docs-section" id="docs">
 				<h2>Installation and Usage</h2>
@@ -39,6 +19,18 @@ import TimeKeeper from 'react-timekeeper';
 class YourComponent extends React.Component {
 	render(){
 		return <TimeKeeper />;
+	}
+} </code></pre>
+
+				<p className="text">
+					And in order to activate the 24 hour format, just add the 'hourMode' parameter.
+				</p>
+				<pre><code className="javascript">import React from 'react';
+import TimeKeeper from 'react-timekeeper';
+
+class YourComponent extends React.Component {
+	render(){
+		return <TimeKeeper hourMode={'hour24'} />;
 	}
 } </code></pre>
 			</section>

--- a/docs/js/intro.jsx
+++ b/docs/js/intro.jsx
@@ -1,34 +1,12 @@
 import React from 'react'
-import TimeKeeper from 'react-timekeeper'
 import {Github, Plug} from './icons'
 
+import Intro_12 from './intro_12'
+import Intro_24 from './intro_24'
+
+
 class Intro extends React.Component {
-	constructor(props){
-		super(props)
-		const date = new Date();
-
-		const h = date.getHours() % 12
-		const hour = h === 0 ? 12 : h
-		const min = ('0' + date.getMinutes()).slice(-2)
-		const meridiem = date.getHours() > 12 ? 'PM' : 'AM'
-		const dateString = `${hour}:${min} ${meridiem}`;
-		this.state = {
-			demoTime: dateString,
-			displayDemo: true
-		}
-
-		this.updateDemoTime = this.updateDemoTime.bind(this)
-	}
-	updateDemoTime(data){
-		this.setState({ demoTime: data.formatted})
-	}
-	toggleDemoDisplay(val){
-		this.setState({displayDemo: val})
-	}
-
-
 	render(){
-		const state = this.state
 		return (
 			<section className="intro-demo">
 				<h1>React Timekeeper</h1>
@@ -37,30 +15,8 @@ class Intro extends React.Component {
 					<a href="https://github.com/catc/react-timekeeper"><Github /> Source</a>
 					<a href="#examples"><Plug /> Examples</a>
 				</div>
-				<div className="intro-demo-wrapper">
-					<div className="intro-demo-picker">
-						{state.displayDemo ?
-							<div className="intro-demo-picker__wrapper">
-								<TimeKeeper
-									time={state.demoTime}
-									onChange={this.updateDemoTime}
-									onDoneClick={() => {
-										this.toggleDemoDisplay(false)
-									}}
-									switchToMinuteOnHourSelect={true}
-								/>
-							</div>
-							:
-							false
-						}
-					</div>
-					<span
-						onClick={() => {this.toggleDemoDisplay(true) }}
-						className="selected-demo-time"
-					>The time is currently <strong>{state.demoTime}</strong>
-						{this.state.displayDemo ? false : <span className="selected-demo-time__hint">Click to open</span>}
-					</span>
-				</div>
+				<Intro_12/>
+				<Intro_24/>
 			</section>
 		)
 	}

--- a/docs/js/intro_12.jsx
+++ b/docs/js/intro_12.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import TimeKeeper from 'react-timekeeper'
+
+
+class Intro_12 extends React.Component {
+	constructor(props){
+		super(props)
+		const date = new Date();
+
+		const h = date.getHours() % 12
+		const hour = h === 0 ? 12 : h
+		const min = ('0' + date.getMinutes()).slice(-2)
+		const meridiem = date.getHours() > 12 ? 'PM' : 'AM'
+		const dateString = `${hour}:${min} ${meridiem}`;
+		this.state = {
+			demoTime: dateString,
+			displayDemo: true
+		}
+
+		this.updateDemoTime = this.updateDemoTime.bind(this)
+	}
+	updateDemoTime(data){
+		this.setState({ demoTime: data.formatted})
+	}
+	toggleDemoDisplay(val){
+		this.setState({displayDemo: val})
+	}
+
+
+	render(){
+		const state = this.state
+		return (
+			<div className="intro-demo-wrapper">
+				<div className="intro-demo-picker">
+					{state.displayDemo ?
+						<div className="intro-demo-picker__wrapper">
+							<TimeKeeper
+								time={state.demoTime}
+								onChange={this.updateDemoTime}
+								onDoneClick={() => {
+									this.toggleDemoDisplay(false)
+								}}
+								switchToMinuteOnHourSelect={true}
+							/>
+						</div>
+						:
+						false
+					}
+				</div>
+				<span
+					onClick={() => {this.toggleDemoDisplay(true) }}
+					className="selected-demo-time"
+				>The time is currently <strong>{state.demoTime}</strong>
+					{this.state.displayDemo ? false : <span className="selected-demo-time__hint">Click to open</span>}
+				</span>
+			</div>
+		)
+	}
+}
+
+export default Intro_12

--- a/docs/js/intro_24.jsx
+++ b/docs/js/intro_24.jsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import TimeKeeper from 'react-timekeeper'
+
+
+class Intro_24 extends React.Component {
+	constructor(props){
+		super(props)
+		const date = new Date();
+
+		const hour = date.getHours()
+		const min = ('0' + date.getMinutes()).slice(-2)
+		const dateString = `${hour}:${min}`;
+		this.state = {
+			demoTime: dateString,
+			displayDemo: true
+		}
+
+		this.updateDemoTime = this.updateDemoTime.bind(this)
+	}
+	updateDemoTime(data){
+		this.setState({ demoTime: data.formatted24 })
+	}
+	toggleDemoDisplay(val){
+		this.setState({displayDemo: val})
+	}
+
+
+	render(){
+		const state = this.state
+		return (
+			<div className="intro-demo-wrapper">
+				<div className="intro-demo-picker">
+					{state.displayDemo ?
+						<div className="intro-demo-picker__wrapper">
+							<TimeKeeper
+								time={state.demoTime}
+								hourMode={'hour24'}
+								onChange={this.updateDemoTime}
+								onDoneClick={() => {
+									this.toggleDemoDisplay(false)
+								}}
+								switchToMinuteOnHourSelect={true}
+							/>
+						</div>
+						:
+						false
+					}
+				</div>
+				<span
+					onClick={() => {this.toggleDemoDisplay(true) }}
+					className="selected-demo-time"
+				>The time is currently <strong>{state.demoTime}</strong>
+					{this.state.displayDemo ? false : <span className="selected-demo-time__hint">Click to open</span>}
+				</span>
+			</div>
+		)
+	}
+}
+
+export default Intro_24

--- a/src/components/ClockWrapper.jsx
+++ b/src/components/ClockWrapper.jsx
@@ -58,6 +58,7 @@ export class ClockWrapper extends React.Component {
 				<Clock
 					config={props.config}
 					hour={props.hour}
+					hour24={props.hour24}
 					minute={props.minute}
 					unit={props.unit}
 
@@ -66,6 +67,7 @@ export class ClockWrapper extends React.Component {
 					clockWrapperEl={this.clockWrapperEl}
 				/>
 
+				{props.mode === 'hour' &&
 				<div style={styles.meridiemWrapper} className="react-timekeeper__meridiem-toggle-wrapper">
 					<button
 						type="button"
@@ -87,6 +89,7 @@ export class ClockWrapper extends React.Component {
 						onClick={() => { props.changeMeridiem('pm') }}
 					>PM</button>
 				</div>
+				}
 			</div>
 		)
 	}
@@ -94,14 +97,20 @@ export class ClockWrapper extends React.Component {
 
 ClockWrapper.propTypes = {
 	config: PropTypes.object.isRequired,
+	mode: PropTypes.oneOf(['hour', 'hour24']),
 	unit: PropTypes.string.isRequired,
-	hour: PropTypes.number.isRequired,
+	hour: PropTypes.number,
+	hour24: PropTypes.number,
 	minute: PropTypes.number.isRequired,
 	meridiem: PropTypes.string.isRequired,
 
 	changeHour: PropTypes.func.isRequired,
 	changeMinute: PropTypes.func.isRequired,
 	changeMeridiem: PropTypes.func.isRequired
+}
+
+ClockWrapper.defaultProps = {
+	mode: 'hour'
 }
 
 export default Radium(ClockWrapper)

--- a/src/components/Time.jsx
+++ b/src/components/Time.jsx
@@ -26,8 +26,8 @@ export class Time extends React.Component {
 	}
 
 	hourClick(){
-		if (this.props.unit !== 'hour'){
-			this.props.changeUnit('hour')
+		if (this.props.unit !== this.props.mode){
+			this.props.changeUnit(this.props.mode)
 		} else {
 			this.setState({ showHourSelect: !this.state.showHourSelect })
 		}
@@ -56,7 +56,7 @@ export class Time extends React.Component {
 				borderRadius: '3px 3px 0 0',
 			},
 			timeWrapper: {
-				left: 20,
+				left: props.unit === 'hour' ? 20 : 30,
 				position: 'relative'
 			},
 			colon: {
@@ -115,11 +115,11 @@ export class Time extends React.Component {
 							className="react-timekeeper__hour-select"
 							style={[
 								styles.time,
-								props.unit === 'hour' && styles.timeSelected
+								props.unit === props.mode && styles.timeSelected
 							]}
 							onClick={this.hourClick}
 						>
-							{props.hour}
+							{props[props.mode]}
 						</span>
 
 						{this.state.showHourSelect ?
@@ -160,7 +160,7 @@ export class Time extends React.Component {
 						: ''}
 					</div>
 
-
+					{props.mode !== 'hour24' &&
 					<button
 						type="button"
 						onClick={this.toggleMeridiem}
@@ -169,6 +169,7 @@ export class Time extends React.Component {
 					>
 						{props.meridiem}
 					</button>
+					}
 				</div>
 			</div>
 		)
@@ -177,11 +178,16 @@ export class Time extends React.Component {
 
 Time.propTypes = {
 	config: PropTypes.object.isRequired,
+	mode: PropTypes.oneOf(['hour', 'hour24']),
 	unit: PropTypes.string.isRequired,
 	meridiem: PropTypes.string.isRequired,
 
 	changeUnit: PropTypes.func.isRequired,
 	changeMeridiem: PropTypes.func.isRequired
+}
+
+Time.defaultProps = {
+	mode: 'hour'
 }
 
 export default Radium(Time)

--- a/src/components/Timepicker.jsx
+++ b/src/components/Timepicker.jsx
@@ -4,7 +4,7 @@ import debounce from 'lodash/debounce'
 import Radium, { StyleRoot } from 'radium'
 
 import parseTime from '../helpers/parse-time'
-import composeTime from '../helpers/compose-time'
+import {composeTime, composeTime24} from '../helpers/compose-time'
 import ClockWrapper from './ClockWrapper'
 import Time from './Time'
 
@@ -16,14 +16,14 @@ export class Timepicker extends React.Component {
 
 		this.state = {
 			...parseTime(props.time),
-			unit: 'hour'
+			unit: props.hourMode
 		}
 
 		// override any default styles
 		const config = Object.assign({}, defaultConfig, props.config)
 		this.config = config
 
-		this.changeHour =  this.handleTimeChange.bind(this, 'hour')
+		this.changeHour =  this.handleTimeChange.bind(this, props.hourMode)
 		this.changeMinute =  this.handleTimeChange.bind(this, 'minute')
 		this.changeUnit =  this.changeUnit.bind(this)
 		this.changeMeridiem = this.handleMeridiemChange.bind(this)
@@ -45,7 +45,10 @@ export class Timepicker extends React.Component {
 
 	getTime(){
 		const state = this.state;
-		return composeTime(state.hour, state.minute, state.meridiem);
+		if (this.props.hourMode === 'hour24')
+			return composeTime24(state.hour24, state.minute);
+		else
+			return composeTime(state.hour, state.minute, state.meridiem);
 	}
 
 	handleTimeChange(unit, val, canChangeUnit){
@@ -65,7 +68,7 @@ export class Timepicker extends React.Component {
 
 		const props = this.props
 
-		if (canChangeUnit && unit === 'hour' && props.switchToMinuteOnHourSelect){
+		if (canChangeUnit && unit === props.hourMode && props.switchToMinuteOnHourSelect){
 			this.changeUnit('minute')
 		} else if (canChangeUnit && unit === 'minute' && props.closeOnMinuteSelect){
 			props.onDoneClick && props.onDoneClick(this.getTime(), null)
@@ -87,7 +90,7 @@ export class Timepicker extends React.Component {
 		if (currentUnit === newUnit){
 			return;
 		}
-		this.setState({ unit: newUnit })
+		this.setState({ unit: newUnit === 'hour' ? this.props.hourMode : newUnit })
 	}
 
 	render(){
@@ -158,8 +161,10 @@ export class Timepicker extends React.Component {
 
 				<Time
 					config={this.config}
+					mode={this.props.hourMode}
 					unit={state.unit}
 					hour={state.hour}
+					hour24={state.hour24}
 					minute={state.minute}
 					meridiem={state.meridiem}
 
@@ -171,8 +176,10 @@ export class Timepicker extends React.Component {
 				
 				<ClockWrapper
 					config={this.config}
+                    mode={this.props.hourMode}
 					unit={state.unit}
 					hour={state.hour}
+					hour24={state.hour24}
 					minute={state.minute}
 					meridiem={state.meridiem}
 
@@ -190,12 +197,17 @@ export class Timepicker extends React.Component {
 
 Timepicker.propTypes = {
 	time: PropTypes.string,
+	hourMode: PropTypes.oneOf(['hour', 'hour24']),
 	onChange: PropTypes.func,
 	
 	onDoneClick: PropTypes.func,
 	switchToMinuteOnHourSelect: PropTypes.bool,
 	closeOnMinuteSelect: PropTypes.bool,
 	config: PropTypes.object
+}
+
+Timepicker.defaultProps = {
+	hourMode: 'hour'
 }
 
 export default Radium(Timepicker)

--- a/src/components/__tests__/__snapshots__/clock-wrapper.js.snap
+++ b/src/components/__tests__/__snapshots__/clock-wrapper.js.snap
@@ -1,4 +1,4 @@
-exports[`ClockWrapper component renders correctly 1`] = `
+exports[`ClockWrapper component renders correctly when unit is hour 1`] = `
 <div
   className="react-timekeeper__clock-wrapper"
   style={
@@ -315,6 +315,682 @@ exports[`ClockWrapper component renders correctly 1`] = `
           <g
             data-radium={true}
             transform="rotate(360 110 110)">
+            <line
+              stroke={undefined}
+              strokeWidth="1"
+              x1={110}
+              x2={110}
+              y1={110}
+              y2={20} />
+            <circle
+              cx={110}
+              cy={110}
+              fill={undefined}
+              r={1.5} />
+            <circle
+              cx={110}
+              cy={22}
+              fill={undefined}
+              r={17} />
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+  <div
+    className="react-timekeeper__meridiem-toggle-wrapper"
+    style={
+      Object {
+        "marginTop": "-16px",
+        "padding": "0 30px",
+        "position": "relative",
+        "textAlign": "left",
+        "zIndex": 10,
+      }
+    }>
+    <button
+      className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_am "
+      onClick={[Function]}
+      style={
+        Array [
+          Object {
+            "background": undefined,
+            "borderRadius": "99px",
+            "color": undefined,
+            "cursor": "pointer",
+            "display": "inline-block",
+            "fontFamily": undefined,
+            "fontSize": "14px",
+            "height": 38,
+            "lineHeight": "38px",
+            "padding": 0,
+            "textAlign": "center",
+            "transition": "0.15s ease-out",
+            "width": 38,
+          },
+          false,
+        ]
+      }
+      type="button">
+      AM
+    </button>
+    <button
+      className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_pm"
+      onClick={[Function]}
+      style={
+        Array [
+          Object {
+            "background": undefined,
+            "borderRadius": "99px",
+            "color": undefined,
+            "cursor": "pointer",
+            "display": "inline-block",
+            "fontFamily": undefined,
+            "fontSize": "14px",
+            "height": 38,
+            "lineHeight": "38px",
+            "padding": 0,
+            "textAlign": "center",
+            "transition": "0.15s ease-out",
+            "width": 38,
+          },
+          Object {
+            "float": "right",
+          },
+          Object {
+            "background": undefined,
+            "color": undefined,
+          },
+        ]
+      }
+      type="button">
+      PM
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ClockWrapper component renders correctly when unit is hour24 1`] = `
+<div
+  className="react-timekeeper__clock-wrapper"
+  style={
+    Object {
+      "background": undefined,
+      "padding": "18px 0 14px",
+      "textAlign": "center",
+    }
+  }>
+  <div
+    className="react-timekeeper__clock"
+    data-radium={true}
+    onMouseDown={[Function]}
+    onTouchStart={[Function]}
+    style={
+      Object {
+        "background": undefined,
+        "borderRadius": "200px",
+        "cursor": "pointer",
+        "display": "inline-block",
+        "height": "220px",
+        "position": "relative",
+        "width": "220px",
+      }
+    }>
+    <div
+      className="react-timekeeper__clock-animations-wrapper"
+      data-radium={true}>
+      <div
+        className="react-timekeeper__clock-animations"
+        data-radium={true}
+        style={
+          Object {
+            "position": "absolute",
+          }
+        }>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 128.49999999999997,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 31.512196331304843,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          1
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 154.48780366869514,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 57.49999999999997,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          2
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 164,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 92.99999999999999,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          3
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 154.48780366869514,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 128.5,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          4
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 128.50000000000003,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 154.4878036686951,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          5
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 93.00000000000001,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 164,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          6
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 57.5,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 154.48780366869514,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          7
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 31.512196331304878,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 128.50000000000006,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          8
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 22,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 93.00000000000003,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          9
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 31.51219633130482,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 57.50000000000006,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          10
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 57.500000000000014,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 31.512196331304843,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          11
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 92.99999999999997,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 22,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          12
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 155.22539674441623,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 30.774603255583855,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          13
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 178.001472713438,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 70.22392403097817,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          14
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 178.00147271343803,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 115.77607596902178,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          15
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 155.22539674441617,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 155.2253967444162,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          16
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 115.77607596902186,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 178.001472713438,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          17
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 70.22392403097824,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 178.00147271343803,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          18
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 30.77460325558379,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 155.22539674441617,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          19
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 7.998527286561995,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 115.77607596902186,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          20
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 7.998527286561966,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 70.22392403097825,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          21
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 30.774603255583834,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 30.774603255583806,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          22
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 70.22392403097814,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 7.998527286561995,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          23
+        </span>
+        <span
+          data-radium={true}
+          style={
+            Object {
+              "borderRadius": "99px",
+              "color": undefined,
+              "display": "inline-block",
+              "fontSize": "16px",
+              "height": 34,
+              "left": 115.77607596902175,
+              "lineHeight": "34px",
+              "opacity": 1,
+              "pointerEvents": "none",
+              "position": "absolute",
+              "textAlign": "center",
+              "top": 7.998527286561966,
+              "width": 34,
+              "zIndex": 5,
+            }
+          }>
+          0
+        </span>
+        <svg
+          className="react-timekeeper__clock-svgs"
+          data-radium={true}
+          height={220}
+          style={
+            Object {
+              "opacity": 1,
+              "position": "relative",
+            }
+          }
+          viewBox="0 0 220 220"
+          width={220}
+          xmlns="http://www.w3.org/2000/svg">
+          <g
+            data-radium={true}
+            transform="rotate(135 110 110)">
             <line
               stroke={undefined}
               strokeWidth="1"

--- a/src/components/__tests__/__snapshots__/clock.js.snap
+++ b/src/components/__tests__/__snapshots__/clock.js.snap
@@ -313,6 +313,573 @@ exports[`Clock component renders correctly when unit is hour 1`] = `
 </div>
 `;
 
+exports[`Clock component renders correctly when unit is hour24 1`] = `
+<div
+  className="react-timekeeper__clock"
+  onMouseDown={[Function]}
+  onTouchStart={[Function]}
+  style={
+    Object {
+      "background": undefined,
+      "borderRadius": "200px",
+      "cursor": "pointer",
+      "display": "inline-block",
+      "height": "220px",
+      "position": "relative",
+      "width": "220px",
+    }
+  }>
+  <div
+    className="react-timekeeper__clock-animations-wrapper">
+    <div
+      className="react-timekeeper__clock-animations"
+      style={
+        Object {
+          "position": "absolute",
+        }
+      }>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 128.49999999999997,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 31.512196331304843,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        1
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 154.48780366869514,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 57.49999999999997,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        2
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 164,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 92.99999999999999,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        3
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 154.48780366869514,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 128.5,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        4
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 128.50000000000003,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 154.4878036686951,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        5
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 93.00000000000001,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 164,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        6
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 57.5,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 154.48780366869514,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        7
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 31.512196331304878,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 128.50000000000006,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        8
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 22,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 93.00000000000003,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        9
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 31.51219633130482,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 57.50000000000006,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        10
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 57.500000000000014,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 31.512196331304843,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        11
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 92.99999999999997,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 22,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        12
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 155.22539674441623,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 30.774603255583855,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        13
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 178.001472713438,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 70.22392403097817,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        14
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 178.00147271343803,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 115.77607596902178,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        15
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 155.22539674441617,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 155.2253967444162,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        16
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 115.77607596902186,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 178.001472713438,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        17
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 70.22392403097824,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 178.00147271343803,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        18
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 30.77460325558379,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 155.22539674441617,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        19
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 7.998527286561995,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 115.77607596902186,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        20
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 7.998527286561966,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 70.22392403097825,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        21
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 30.774603255583834,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 30.774603255583806,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        22
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 70.22392403097814,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 7.998527286561995,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        23
+      </span>
+      <span
+        style={
+          Object {
+            "borderRadius": "99px",
+            "color": undefined,
+            "display": "inline-block",
+            "fontSize": "16px",
+            "height": 34,
+            "left": 115.77607596902175,
+            "lineHeight": "34px",
+            "opacity": 1,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "textAlign": "center",
+            "top": 7.998527286561966,
+            "width": 34,
+            "zIndex": 5,
+          }
+        }>
+        0
+      </span>
+      <svg
+        className="react-timekeeper__clock-svgs"
+        height={220}
+        style={
+          Object {
+            "opacity": 1,
+            "position": "relative",
+          }
+        }
+        viewBox="0 0 220 220"
+        width={220}
+        xmlns="http://www.w3.org/2000/svg">
+        <g
+          transform="rotate(75 110 110)">
+          <line
+            stroke={undefined}
+            strokeWidth="1"
+            x1={110}
+            x2={110}
+            y1={110}
+            y2={20} />
+          <circle
+            cx={110}
+            cy={110}
+            fill={undefined}
+            r={1.5} />
+          <circle
+            cx={110}
+            cy={22}
+            fill={undefined}
+            r={17} />
+        </g>
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Clock component renders correctly when unit is minute 1`] = `
 <div
   className="react-timekeeper__clock"

--- a/src/components/__tests__/__snapshots__/time-picker.js.snap
+++ b/src/components/__tests__/__snapshots__/time-picker.js.snap
@@ -1,3 +1,1917 @@
+exports[`Timepicker component renders correctly with 24-hours time passed in, and rendered in 24-hours mode 1`] = `
+<div
+  className="react-timekeeper"
+  data-radium={true}
+  style={
+    Object {
+      "background": "#F2F2F2",
+      "borderRadius": "3px",
+      "boxShadow": "0 3px 6px rgba(0,0,0,0.13), 0 3px 6px rgba(0,0,0,0.19)",
+      "display": "inline-block",
+      "fontFamily": "\"Roboto\", sans-serif",
+      "position": "relative",
+      "userSelect": "none",
+      "width": "260px",
+    }
+  }>
+  <style>
+    
+    					.react-timekeeper {
+    						-webkit-tap-highlight-color: transparent;
+    						-webkit-font-smoothing: antialiased;
+    						font-smoothing: antialiased;
+    					}
+    					.react-timekeeper-button-reset {
+    						background: 0;
+    						border: 0;
+    						box-shadow: none;
+    						text-shadow: none;
+    						-webkit-appearance: none;
+    						-moz-appearance: none;
+    						cursor: pointer;
+    					}
+    					.react-timekeeper-button-reset:hover, .react-timekeeper-button-reset:focus, .react-timekeeper-button-reset:active {
+    						outline: none;
+    					}
+    					.react-timekeeper-button-reset::-moz-focus-inner {
+    						border: 0;
+    						padding: 0;
+    					}
+    					.react-timekeeper-noscroll {
+    						overflow: hidden;
+    					}
+    					.react-timekeeper-scrollbar-measure {
+    						width: 100px;
+    						height: 100px;
+    						overflow: scroll;
+    						position: absolute;
+    						top: -9999px;
+    					}
+    				
+  </style>
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "background": "white",
+        "borderRadius": "3px 3px 0 0",
+        "padding": "14px 16px",
+      }
+    }>
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "left": 30,
+          "position": "relative",
+        }
+      }>
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "display": "inline-block",
+            "position": "relative",
+            "textAlign": "right",
+            "width": "72px",
+          }
+        }>
+        <span
+          className="react-timekeeper__hour-select"
+          data-radium={true}
+          onClick={[Function]}
+          style={
+            Object {
+              "animation": "x 0.6s ease-out both",
+              "animationName": "popInOut-radium-animation-a878a005",
+              "color": "#8EDDFD",
+              "cursor": "pointer",
+              "display": "inline-block",
+              "fontSize": "48px",
+              "lineHeight": "normal",
+              "userSelect": "none",
+            }
+          }>
+          17
+        </span>
+        
+      </div>
+      <span
+        data-radium={true}
+        style={
+          Object {
+            "color": "#8C8C8C",
+            "display": "inline-block",
+            "fontSize": "46px",
+            "fontWeight": "500",
+            "lineHeight": "normal",
+            "margin": "0 5px",
+            "verticalAlign": "2px",
+          }
+        }>
+        :
+      </span>
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "display": "inline-block",
+            "position": "relative",
+          }
+        }>
+        <span
+          className="react-timekeeper__minute-select"
+          data-radium={true}
+          onClick={[Function]}
+          style={
+            Object {
+              "color": "#8C8C8C",
+              "cursor": "pointer",
+              "display": "inline-block",
+              "fontSize": "48px",
+              "lineHeight": "normal",
+              "userSelect": "none",
+            }
+          }>
+          04
+        </span>
+        
+      </div>
+    </div>
+  </div>
+  <div
+    className="react-timekeeper__clock-wrapper"
+    data-radium={true}
+    style={
+      Object {
+        "background": "#f4f4f4",
+        "padding": "18px 0 14px",
+        "textAlign": "center",
+      }
+    }>
+    <div
+      className="react-timekeeper__clock"
+      data-radium={true}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "background": "white",
+          "borderRadius": "200px",
+          "cursor": "pointer",
+          "display": "inline-block",
+          "height": "220px",
+          "position": "relative",
+          "width": "220px",
+        }
+      }>
+      <div
+        className="react-timekeeper__clock-animations-wrapper"
+        data-radium={true}>
+        <div
+          className="react-timekeeper__clock-animations"
+          data-radium={true}
+          style={
+            Object {
+              "position": "absolute",
+            }
+          }>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 128.49999999999997,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 31.512196331304843,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            1
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 154.48780366869514,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 57.49999999999997,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            2
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 164,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 92.99999999999999,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            3
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 154.48780366869514,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 128.5,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            4
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 128.50000000000003,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 154.4878036686951,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            5
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 93.00000000000001,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 164,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            6
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 57.5,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 154.48780366869514,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            7
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 31.512196331304878,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 128.50000000000006,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            8
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 22,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 93.00000000000003,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            9
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 31.51219633130482,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 57.50000000000006,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            10
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 57.500000000000014,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 31.512196331304843,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            11
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 92.99999999999997,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 22,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            12
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 155.22539674441623,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 30.774603255583855,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            13
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 178.001472713438,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 70.22392403097817,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            14
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 178.00147271343803,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 115.77607596902178,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            15
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 155.22539674441617,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 155.2253967444162,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            16
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 115.77607596902186,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 178.001472713438,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            17
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 70.22392403097824,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 178.00147271343803,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            18
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 30.77460325558379,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 155.22539674441617,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            19
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 7.998527286561995,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 115.77607596902186,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            20
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 7.998527286561966,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 70.22392403097825,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            21
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 30.774603255583834,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 30.774603255583806,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            22
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 70.22392403097814,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 7.998527286561995,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            23
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 115.77607596902175,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 7.998527286561966,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            0
+          </span>
+          <svg
+            className="react-timekeeper__clock-svgs"
+            data-radium={true}
+            height={220}
+            style={
+              Object {
+                "opacity": 1,
+                "position": "relative",
+              }
+            }
+            viewBox="0 0 220 220"
+            width={220}
+            xmlns="http://www.w3.org/2000/svg">
+            <g
+              data-radium={true}
+              transform="rotate(165 110 110)">
+              <line
+                stroke="#bceaff"
+                strokeWidth="1"
+                x1={110}
+                x2={110}
+                y1={110}
+                y2={20} />
+              <circle
+                cx={110}
+                cy={110}
+                fill="#bceaff"
+                r={1.5} />
+              <circle
+                cx={110}
+                cy={22}
+                fill="#e6f7ff"
+                r={17} />
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "@keyframes popInOut-radium-animation-a878a005 {
+      from{transform: scale(1);}
+      30%{transform: scale(0.88);}
+      60%{transform: scale(1.05);}
+      to{transform: scale(1);}
+      }
+      ",
+      }
+    } />
+</div>
+`;
+
+exports[`Timepicker component renders correctly with 24-hours time passed in, but rendered in am/pm mode 1`] = `
+<div
+  className="react-timekeeper"
+  data-radium={true}
+  style={
+    Object {
+      "background": "#F2F2F2",
+      "borderRadius": "3px",
+      "boxShadow": "0 3px 6px rgba(0,0,0,0.13), 0 3px 6px rgba(0,0,0,0.19)",
+      "display": "inline-block",
+      "fontFamily": "\"Roboto\", sans-serif",
+      "position": "relative",
+      "userSelect": "none",
+      "width": "260px",
+    }
+  }>
+  <style>
+    
+    					.react-timekeeper {
+    						-webkit-tap-highlight-color: transparent;
+    						-webkit-font-smoothing: antialiased;
+    						font-smoothing: antialiased;
+    					}
+    					.react-timekeeper-button-reset {
+    						background: 0;
+    						border: 0;
+    						box-shadow: none;
+    						text-shadow: none;
+    						-webkit-appearance: none;
+    						-moz-appearance: none;
+    						cursor: pointer;
+    					}
+    					.react-timekeeper-button-reset:hover, .react-timekeeper-button-reset:focus, .react-timekeeper-button-reset:active {
+    						outline: none;
+    					}
+    					.react-timekeeper-button-reset::-moz-focus-inner {
+    						border: 0;
+    						padding: 0;
+    					}
+    					.react-timekeeper-noscroll {
+    						overflow: hidden;
+    					}
+    					.react-timekeeper-scrollbar-measure {
+    						width: 100px;
+    						height: 100px;
+    						overflow: scroll;
+    						position: absolute;
+    						top: -9999px;
+    					}
+    				
+  </style>
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "background": "white",
+        "borderRadius": "3px 3px 0 0",
+        "padding": "14px 16px",
+      }
+    }>
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "left": 20,
+          "position": "relative",
+        }
+      }>
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "display": "inline-block",
+            "position": "relative",
+            "textAlign": "right",
+            "width": "72px",
+          }
+        }>
+        <span
+          className="react-timekeeper__hour-select"
+          data-radium={true}
+          onClick={[Function]}
+          style={
+            Object {
+              "animation": "x 0.6s ease-out both",
+              "animationName": "popInOut-radium-animation-a878a005",
+              "color": "#8EDDFD",
+              "cursor": "pointer",
+              "display": "inline-block",
+              "fontSize": "48px",
+              "lineHeight": "normal",
+              "userSelect": "none",
+            }
+          }>
+          5
+        </span>
+        
+      </div>
+      <span
+        data-radium={true}
+        style={
+          Object {
+            "color": "#8C8C8C",
+            "display": "inline-block",
+            "fontSize": "46px",
+            "fontWeight": "500",
+            "lineHeight": "normal",
+            "margin": "0 5px",
+            "verticalAlign": "2px",
+          }
+        }>
+        :
+      </span>
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "display": "inline-block",
+            "position": "relative",
+          }
+        }>
+        <span
+          className="react-timekeeper__minute-select"
+          data-radium={true}
+          onClick={[Function]}
+          style={
+            Object {
+              "color": "#8C8C8C",
+              "cursor": "pointer",
+              "display": "inline-block",
+              "fontSize": "48px",
+              "lineHeight": "normal",
+              "userSelect": "none",
+            }
+          }>
+          04
+        </span>
+        
+      </div>
+      <button
+        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle"
+        data-radium={true}
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#8C8C8C",
+            "display": "inline-block",
+            "fontFamily": "\"Roboto\", sans-serif",
+            "fontSize": "13px",
+            "marginLeft": "2px",
+            "padding": "10px 8px",
+            "textTransform": "uppercase",
+            "verticalAlign": "1px",
+          }
+        }
+        type="button">
+        pm
+      </button>
+    </div>
+  </div>
+  <div
+    className="react-timekeeper__clock-wrapper"
+    data-radium={true}
+    style={
+      Object {
+        "background": "#f4f4f4",
+        "padding": "18px 0 14px",
+        "textAlign": "center",
+      }
+    }>
+    <div
+      className="react-timekeeper__clock"
+      data-radium={true}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "background": "white",
+          "borderRadius": "200px",
+          "cursor": "pointer",
+          "display": "inline-block",
+          "height": "220px",
+          "position": "relative",
+          "width": "220px",
+        }
+      }>
+      <div
+        className="react-timekeeper__clock-animations-wrapper"
+        data-radium={true}>
+        <div
+          className="react-timekeeper__clock-animations"
+          data-radium={true}
+          style={
+            Object {
+              "position": "absolute",
+            }
+          }>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 136.99999999999997,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 16.789764466969388,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            1
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 169.21023553303058,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 48.99999999999996,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            2
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 181,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 92.99999999999999,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            3
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 169.21023553303058,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 137,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            4
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 137.00000000000006,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 169.21023553303058,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            5
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 93.00000000000003,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 181,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            6
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 49,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 169.21023553303058,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            7
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 16.789764466969416,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 137.00000000000006,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            8
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 5,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 93.00000000000003,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            9
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 16.78976446696936,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 49.00000000000007,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            10
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 49.00000000000003,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 16.789764466969388,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            11
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 92.99999999999997,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 5,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            12
+          </span>
+          <svg
+            className="react-timekeeper__clock-svgs"
+            data-radium={true}
+            height={220}
+            style={
+              Object {
+                "opacity": 1,
+                "position": "relative",
+              }
+            }
+            viewBox="0 0 220 220"
+            width={220}
+            xmlns="http://www.w3.org/2000/svg">
+            <g
+              data-radium={true}
+              transform="rotate(150 110 110)">
+              <line
+                stroke="#bceaff"
+                strokeWidth="1"
+                x1={110}
+                x2={110}
+                y1={110}
+                y2={20} />
+              <circle
+                cx={110}
+                cy={110}
+                fill="#bceaff"
+                r={1.5} />
+              <circle
+                cx={110}
+                cy={22}
+                fill="#e6f7ff"
+                r={17} />
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className="react-timekeeper__meridiem-toggle-wrapper"
+      data-radium={true}
+      style={
+        Object {
+          "marginTop": "-16px",
+          "padding": "0 30px",
+          "position": "relative",
+          "textAlign": "left",
+          "zIndex": 10,
+        }
+      }>
+      <button
+        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_am "
+        data-radium={true}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "white",
+            "borderRadius": "99px",
+            "color": "#898989",
+            "cursor": "pointer",
+            "display": "inline-block",
+            "fontFamily": "\"Roboto\", sans-serif",
+            "fontSize": "14px",
+            "height": 38,
+            "lineHeight": "38px",
+            "padding": 0,
+            "textAlign": "center",
+            "transition": "0.15s ease-out",
+            "width": 38,
+          }
+        }
+        type="button">
+        AM
+      </button>
+      <button
+        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_pm"
+        data-radium={true}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#E1EFF6",
+            "borderRadius": "99px",
+            "color": "#898989",
+            "cursor": "pointer",
+            "display": "inline-block",
+            "float": "right",
+            "fontFamily": "\"Roboto\", sans-serif",
+            "fontSize": "14px",
+            "height": 38,
+            "lineHeight": "38px",
+            "padding": 0,
+            "textAlign": "center",
+            "transition": "0.15s ease-out",
+            "width": 38,
+          }
+        }
+        type="button">
+        PM
+      </button>
+    </div>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "@keyframes popInOut-radium-animation-a878a005 {
+      from{transform: scale(1);}
+      30%{transform: scale(0.88);}
+      60%{transform: scale(1.05);}
+      to{transform: scale(1);}
+      }
+      ",
+      }
+    } />
+</div>
+`;
+
+exports[`Timepicker component renders correctly with am-time passed in 1`] = `
+<div
+  className="react-timekeeper"
+  data-radium={true}
+  style={
+    Object {
+      "background": "#F2F2F2",
+      "borderRadius": "3px",
+      "boxShadow": "0 3px 6px rgba(0,0,0,0.13), 0 3px 6px rgba(0,0,0,0.19)",
+      "display": "inline-block",
+      "fontFamily": "\"Roboto\", sans-serif",
+      "position": "relative",
+      "userSelect": "none",
+      "width": "260px",
+    }
+  }>
+  <style>
+    
+    					.react-timekeeper {
+    						-webkit-tap-highlight-color: transparent;
+    						-webkit-font-smoothing: antialiased;
+    						font-smoothing: antialiased;
+    					}
+    					.react-timekeeper-button-reset {
+    						background: 0;
+    						border: 0;
+    						box-shadow: none;
+    						text-shadow: none;
+    						-webkit-appearance: none;
+    						-moz-appearance: none;
+    						cursor: pointer;
+    					}
+    					.react-timekeeper-button-reset:hover, .react-timekeeper-button-reset:focus, .react-timekeeper-button-reset:active {
+    						outline: none;
+    					}
+    					.react-timekeeper-button-reset::-moz-focus-inner {
+    						border: 0;
+    						padding: 0;
+    					}
+    					.react-timekeeper-noscroll {
+    						overflow: hidden;
+    					}
+    					.react-timekeeper-scrollbar-measure {
+    						width: 100px;
+    						height: 100px;
+    						overflow: scroll;
+    						position: absolute;
+    						top: -9999px;
+    					}
+    				
+  </style>
+  <div
+    data-radium={true}
+    style={
+      Object {
+        "background": "white",
+        "borderRadius": "3px 3px 0 0",
+        "padding": "14px 16px",
+      }
+    }>
+    <div
+      data-radium={true}
+      style={
+        Object {
+          "left": 20,
+          "position": "relative",
+        }
+      }>
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "display": "inline-block",
+            "position": "relative",
+            "textAlign": "right",
+            "width": "72px",
+          }
+        }>
+        <span
+          className="react-timekeeper__hour-select"
+          data-radium={true}
+          onClick={[Function]}
+          style={
+            Object {
+              "animation": "x 0.6s ease-out both",
+              "animationName": "popInOut-radium-animation-a878a005",
+              "color": "#8EDDFD",
+              "cursor": "pointer",
+              "display": "inline-block",
+              "fontSize": "48px",
+              "lineHeight": "normal",
+              "userSelect": "none",
+            }
+          }>
+          6
+        </span>
+        
+      </div>
+      <span
+        data-radium={true}
+        style={
+          Object {
+            "color": "#8C8C8C",
+            "display": "inline-block",
+            "fontSize": "46px",
+            "fontWeight": "500",
+            "lineHeight": "normal",
+            "margin": "0 5px",
+            "verticalAlign": "2px",
+          }
+        }>
+        :
+      </span>
+      <div
+        data-radium={true}
+        style={
+          Object {
+            "display": "inline-block",
+            "position": "relative",
+          }
+        }>
+        <span
+          className="react-timekeeper__minute-select"
+          data-radium={true}
+          onClick={[Function]}
+          style={
+            Object {
+              "color": "#8C8C8C",
+              "cursor": "pointer",
+              "display": "inline-block",
+              "fontSize": "48px",
+              "lineHeight": "normal",
+              "userSelect": "none",
+            }
+          }>
+          42
+        </span>
+        
+      </div>
+      <button
+        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle"
+        data-radium={true}
+        onClick={[Function]}
+        style={
+          Object {
+            "color": "#8C8C8C",
+            "display": "inline-block",
+            "fontFamily": "\"Roboto\", sans-serif",
+            "fontSize": "13px",
+            "marginLeft": "2px",
+            "padding": "10px 8px",
+            "textTransform": "uppercase",
+            "verticalAlign": "1px",
+          }
+        }
+        type="button">
+        am
+      </button>
+    </div>
+  </div>
+  <div
+    className="react-timekeeper__clock-wrapper"
+    data-radium={true}
+    style={
+      Object {
+        "background": "#f4f4f4",
+        "padding": "18px 0 14px",
+        "textAlign": "center",
+      }
+    }>
+    <div
+      className="react-timekeeper__clock"
+      data-radium={true}
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+      style={
+        Object {
+          "background": "white",
+          "borderRadius": "200px",
+          "cursor": "pointer",
+          "display": "inline-block",
+          "height": "220px",
+          "position": "relative",
+          "width": "220px",
+        }
+      }>
+      <div
+        className="react-timekeeper__clock-animations-wrapper"
+        data-radium={true}>
+        <div
+          className="react-timekeeper__clock-animations"
+          data-radium={true}
+          style={
+            Object {
+              "position": "absolute",
+            }
+          }>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 136.99999999999997,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 16.789764466969388,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            1
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 169.21023553303058,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 48.99999999999996,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            2
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 181,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 92.99999999999999,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            3
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 169.21023553303058,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 137,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            4
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 137.00000000000006,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 169.21023553303058,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            5
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 93.00000000000003,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 181,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            6
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 49,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 169.21023553303058,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            7
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 16.789764466969416,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 137.00000000000006,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            8
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 5,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 93.00000000000003,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            9
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 16.78976446696936,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 49.00000000000007,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            10
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 49.00000000000003,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 16.789764466969388,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            11
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 92.99999999999997,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 5,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            12
+          </span>
+          <svg
+            className="react-timekeeper__clock-svgs"
+            data-radium={true}
+            height={220}
+            style={
+              Object {
+                "opacity": 1,
+                "position": "relative",
+              }
+            }
+            viewBox="0 0 220 220"
+            width={220}
+            xmlns="http://www.w3.org/2000/svg">
+            <g
+              data-radium={true}
+              transform="rotate(180 110 110)">
+              <line
+                stroke="#bceaff"
+                strokeWidth="1"
+                x1={110}
+                x2={110}
+                y1={110}
+                y2={20} />
+              <circle
+                cx={110}
+                cy={110}
+                fill="#bceaff"
+                r={1.5} />
+              <circle
+                cx={110}
+                cy={22}
+                fill="#e6f7ff"
+                r={17} />
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+    <div
+      className="react-timekeeper__meridiem-toggle-wrapper"
+      data-radium={true}
+      style={
+        Object {
+          "marginTop": "-16px",
+          "padding": "0 30px",
+          "position": "relative",
+          "textAlign": "left",
+          "zIndex": 10,
+        }
+      }>
+      <button
+        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_am "
+        data-radium={true}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#E1EFF6",
+            "borderRadius": "99px",
+            "color": "#898989",
+            "cursor": "pointer",
+            "display": "inline-block",
+            "fontFamily": "\"Roboto\", sans-serif",
+            "fontSize": "14px",
+            "height": 38,
+            "lineHeight": "38px",
+            "padding": 0,
+            "textAlign": "center",
+            "transition": "0.15s ease-out",
+            "width": 38,
+          }
+        }
+        type="button">
+        AM
+      </button>
+      <button
+        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_pm"
+        data-radium={true}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "white",
+            "borderRadius": "99px",
+            "color": "#898989",
+            "cursor": "pointer",
+            "display": "inline-block",
+            "float": "right",
+            "fontFamily": "\"Roboto\", sans-serif",
+            "fontSize": "14px",
+            "height": 38,
+            "lineHeight": "38px",
+            "padding": 0,
+            "textAlign": "center",
+            "transition": "0.15s ease-out",
+            "width": 38,
+          }
+        }
+        type="button">
+        PM
+      </button>
+    </div>
+  </div>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "@keyframes popInOut-radium-animation-a878a005 {
+      from{transform: scale(1);}
+      30%{transform: scale(0.88);}
+      60%{transform: scale(1.05);}
+      to{transform: scale(1);}
+      }
+      ",
+      }
+    } />
+</div>
+`;
+
 exports[`Timepicker component renders correctly with no time 1`] = `
 <div
   className="react-timekeeper"
@@ -575,7 +2489,7 @@ exports[`Timepicker component renders correctly with no time 1`] = `
 </div>
 `;
 
-exports[`Timepicker component renders correctly with time passed in 1`] = `
+exports[`Timepicker component renders correctly with pm-time passed in, but rendered in 24-hours mode 1`] = `
 <div
   className="react-timekeeper"
   data-radium={true}
@@ -639,7 +2553,7 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
       data-radium={true}
       style={
         Object {
-          "left": 20,
+          "left": 30,
           "position": "relative",
         }
       }>
@@ -669,7 +2583,7 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
               "userSelect": "none",
             }
           }>
-          6
+          23
         </span>
         
       </div>
@@ -710,29 +2624,10 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
               "userSelect": "none",
             }
           }>
-          42
+          56
         </span>
         
       </div>
-      <button
-        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle"
-        data-radium={true}
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#8C8C8C",
-            "display": "inline-block",
-            "fontFamily": "\"Roboto\", sans-serif",
-            "fontSize": "13px",
-            "marginLeft": "2px",
-            "padding": "10px 8px",
-            "textTransform": "uppercase",
-            "verticalAlign": "1px",
-          }
-        }
-        type="button">
-        am
-      </button>
     </div>
   </div>
   <div
@@ -781,13 +2676,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 136.99999999999997,
+                "left": 128.49999999999997,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 16.789764466969388,
+                "top": 31.512196331304843,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -803,13 +2698,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 169.21023553303058,
+                "left": 154.48780366869514,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 48.99999999999996,
+                "top": 57.49999999999997,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -825,7 +2720,7 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 181,
+                "left": 164,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
@@ -847,13 +2742,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 169.21023553303058,
+                "left": 154.48780366869514,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 137,
+                "top": 128.5,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -869,13 +2764,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 137.00000000000006,
+                "left": 128.50000000000003,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 169.21023553303058,
+                "top": 154.4878036686951,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -891,13 +2786,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 93.00000000000003,
+                "left": 93.00000000000001,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 181,
+                "top": 164,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -913,13 +2808,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 49,
+                "left": 57.5,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 169.21023553303058,
+                "top": 154.48780366869514,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -935,13 +2830,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 16.789764466969416,
+                "left": 31.512196331304878,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 137.00000000000006,
+                "top": 128.50000000000006,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -957,7 +2852,7 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 5,
+                "left": 22,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
@@ -979,13 +2874,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 16.78976446696936,
+                "left": 31.51219633130482,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 49.00000000000007,
+                "top": 57.50000000000006,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -1001,13 +2896,13 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "display": "inline-block",
                 "fontSize": "16px",
                 "height": 34,
-                "left": 49.00000000000003,
+                "left": 57.500000000000014,
                 "lineHeight": "34px",
                 "opacity": 1,
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 16.789764466969388,
+                "top": 31.512196331304843,
                 "width": 34,
                 "zIndex": 5,
               }
@@ -1029,12 +2924,276 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
                 "pointerEvents": "none",
                 "position": "absolute",
                 "textAlign": "center",
-                "top": 5,
+                "top": 22,
                 "width": 34,
                 "zIndex": 5,
               }
             }>
             12
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 155.22539674441623,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 30.774603255583855,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            13
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 178.001472713438,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 70.22392403097817,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            14
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 178.00147271343803,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 115.77607596902178,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            15
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 155.22539674441617,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 155.2253967444162,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            16
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 115.77607596902186,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 178.001472713438,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            17
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 70.22392403097824,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 178.00147271343803,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            18
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 30.77460325558379,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 155.22539674441617,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            19
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 7.998527286561995,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 115.77607596902186,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            20
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 7.998527286561966,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 70.22392403097825,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            21
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 30.774603255583834,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 30.774603255583806,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            22
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 70.22392403097814,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 7.998527286561995,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            23
+          </span>
+          <span
+            data-radium={true}
+            style={
+              Object {
+                "borderRadius": "99px",
+                "color": "#999999",
+                "display": "inline-block",
+                "fontSize": "16px",
+                "height": 34,
+                "left": 115.77607596902175,
+                "lineHeight": "34px",
+                "opacity": 1,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "textAlign": "center",
+                "top": 7.998527286561966,
+                "width": 34,
+                "zIndex": 5,
+              }
+            }>
+            0
           </span>
           <svg
             className="react-timekeeper__clock-svgs"
@@ -1051,7 +3210,7 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
             xmlns="http://www.w3.org/2000/svg">
             <g
               data-radium={true}
-              transform="rotate(180 110 110)">
+              transform="rotate(345 110 110)">
               <line
                 stroke="#bceaff"
                 strokeWidth="1"
@@ -1073,68 +3232,6 @@ exports[`Timepicker component renders correctly with time passed in 1`] = `
           </svg>
         </div>
       </div>
-    </div>
-    <div
-      className="react-timekeeper__meridiem-toggle-wrapper"
-      data-radium={true}
-      style={
-        Object {
-          "marginTop": "-16px",
-          "padding": "0 30px",
-          "position": "relative",
-          "textAlign": "left",
-          "zIndex": 10,
-        }
-      }>
-      <button
-        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_am "
-        data-radium={true}
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#E1EFF6",
-            "borderRadius": "99px",
-            "color": "#898989",
-            "cursor": "pointer",
-            "display": "inline-block",
-            "fontFamily": "\"Roboto\", sans-serif",
-            "fontSize": "14px",
-            "height": 38,
-            "lineHeight": "38px",
-            "padding": 0,
-            "textAlign": "center",
-            "transition": "0.15s ease-out",
-            "width": 38,
-          }
-        }
-        type="button">
-        AM
-      </button>
-      <button
-        className="react-timekeeper-button-reset react-timekeeper__meridiem-toggle type_pm"
-        data-radium={true}
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "white",
-            "borderRadius": "99px",
-            "color": "#898989",
-            "cursor": "pointer",
-            "display": "inline-block",
-            "float": "right",
-            "fontFamily": "\"Roboto\", sans-serif",
-            "fontSize": "14px",
-            "height": 38,
-            "lineHeight": "38px",
-            "padding": 0,
-            "textAlign": "center",
-            "transition": "0.15s ease-out",
-            "width": 38,
-          }
-        }
-        type="button">
-        PM
-      </button>
     </div>
   </div>
   <style

--- a/src/components/__tests__/clock-wrapper.js
+++ b/src/components/__tests__/clock-wrapper.js
@@ -6,27 +6,47 @@ import { ClockWrapper } from '../ClockWrapper';
 
 describe('ClockWrapper component', () => {
 	const hour = 12;
+	const hour24 = 16;
 	const minute = 30;
 	const unit = 'hour';
+	const unit24 = 'hour24';
 
 	const changeHour = jest.fn();
 	const changeMinute = jest.fn();
 	const changeMeridiem = jest.fn();
 
-	test('renders correctly', () => {
-		const tree = renderer.create(
-			<ClockWrapper
-				config={{}}
-				unit={unit}
-				hour={hour}
-				minute={minute}
-				meridiem="pm"
-				changeHour={changeHour}
-				changeMinute={changeMinute}
-				changeMeridiem={changeMeridiem}
-			/>
-		).toJSON()
-		expect(tree).toMatchSnapshot()
+	describe('renders correctly', () => {
+		test('when unit is hour', () => {
+			const tree = renderer.create(
+				<ClockWrapper
+					config={{}}
+					unit={unit}
+					hour={hour}
+					minute={minute}
+					meridiem="pm"
+					changeHour={changeHour}
+					changeMinute={changeMinute}
+					changeMeridiem={changeMeridiem}
+				/>
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+		test('when unit is hour24', () => {
+			const tree = renderer.create(
+				<ClockWrapper
+					config={{}}
+					unit={unit24}
+					hour24={hour24}
+					minute={minute}
+					changeHour={changeHour}
+					changeMinute={changeMinute}
+					// props to suppress proptypes warnings
+                    meridiem="pm"
+					changeMeridiem={changeMeridiem}
+				/>
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
 	})
 
 	test('triggers change meridiem', () => {

--- a/src/components/__tests__/clock.js
+++ b/src/components/__tests__/clock.js
@@ -5,6 +5,7 @@ import { Clock } from '../Clock';
 
 describe('Clock component', () => {
 	const hour = 4;
+	const hour24 = 14;
 	const minute = 42;
 
 	const changeHour = jest.fn();
@@ -18,6 +19,21 @@ describe('Clock component', () => {
 					config={{}}
 					unit={unit}
 					hour={hour}
+					minute={minute}
+					changeHour={changeHour}
+					changeMinute={changeMinute}
+				/>
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+		test('when unit is hour24', () => {
+			const unit = 'hour24';
+			const tree = renderer.create(
+				<Clock
+					config={{}}
+					mode={'hour24'}
+					unit={unit}
+					hour24={hour24}
 					minute={minute}
 					changeHour={changeHour}
 					changeMinute={changeMinute}

--- a/src/components/__tests__/time-picker.js
+++ b/src/components/__tests__/time-picker.js
@@ -13,10 +13,39 @@ describe('Timepicker component', () => {
 			expect(tree).toMatchSnapshot()
 		})
 
-		test('with time passed in', () => {
+		test('with am-time passed in', () => {
 			const tree = renderer.create(
 				<Timepicker
-					time="6:42"
+					time="6:42 am"
+				/>
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+
+		test('with pm-time passed in, but rendered in 24-hours mode', () => {
+			const tree = renderer.create(
+				<Timepicker
+					time="11:56 pm"
+					hourMode={'hour24'}
+				/>
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+
+		test('with 24-hours time passed in, but rendered in am/pm mode', () => {
+			const tree = renderer.create(
+				<Timepicker
+					time="17:04"
+				/>
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+
+		test('with 24-hours time passed in, and rendered in 24-hours mode', () => {
+			const tree = renderer.create(
+				<Timepicker
+					time="17:04"
+					hourMode={'hour24'}
 				/>
 			).toJSON()
 			expect(tree).toMatchSnapshot()

--- a/src/components/__tests__/time.js
+++ b/src/components/__tests__/time.js
@@ -36,6 +36,42 @@ describe('Time component', () => {
 			timeRendered.find(HOUR_SELECT_BUTTON).simulate('click');
 			expect( timeRendered.find(`.time-dropdown-${unit}`).length ).toEqual(1);
 		})
+
+		// should be present
+		test('meridiem is visible', () => {
+			expect( timeRendered.find(MERIDIEM_TOGGLE).length ).toEqual(1);
+		})
+	})
+
+	describe('current unit is hour24', () => {
+		const unit = 'hour24'
+		const timeRendered = mount(
+			<Time
+				config={{}}
+				mode={'hour24'}
+				unit={unit}
+				changeUnit={changeUnit}
+				// props to suppress proptypes warnings
+                meridiem='am'
+				changeMeridiem={jest.fn()}
+			/>
+		)
+
+		test('minute is selected', () => {
+			timeRendered.find(MINUTE_SELECT_BUTTON).simulate('click');
+			expect(changeUnit).lastCalledWith('minute');
+		})
+
+        // should open TimeDropdown
+		test('hour is selected', () => {
+			timeRendered.find(HOUR_SELECT_BUTTON).simulate('click');
+			expect( timeRendered.find('.time-dropdown-hour').length ).toEqual(1);
+		})
+
+        // should not be present
+		test('meridiem is hidden', () => {
+			expect( timeRendered.find(MERIDIEM_TOGGLE).length ).toEqual(0);
+		})
 	})
 
 	describe('current unit is minute', () => {

--- a/src/helpers/__tests__/compose-time.js
+++ b/src/helpers/__tests__/compose-time.js
@@ -1,10 +1,21 @@
-import compose from '../compose-time';
+import {composeTime as compose, composeTime24 as compose24} from '../compose-time';
 
 describe('helpers/compose-time', () => {
 	test('formatted24', () => {
 		expect( compose(1, 30, 'am') ).toHaveProperty('formatted24', '1:30')
 		expect( compose(1, 30, 'pm') ).toHaveProperty('formatted24', '13:30')
-		expect( compose(12, 30, 'pm') ).toHaveProperty('formatted24', '12:30')
 		expect( compose(12, 30, 'am') ).toHaveProperty('formatted24', '0:30')
+		expect( compose(12, 30, 'pm') ).toHaveProperty('formatted24', '12:30')
+	})
+	test('hour24', () => {
+		expect( compose(1, 30, 'am') ).toHaveProperty('hour24', 1)
+		expect( compose(1, 30, 'pm') ).toHaveProperty('hour24', 13)
+		expect( compose(12, 30, 'am') ).toHaveProperty('hour24', 0)
+		expect( compose(12, 30, 'pm') ).toHaveProperty('hour24', 12)
+		expect( compose24(1, 30) ).toHaveProperty('hour24', 1)
+		expect( compose24(13, 30) ).toHaveProperty('hour24', 13)
+		expect( compose24(24, 30) ).toHaveProperty('hour24', 0)
+		expect( compose24(0, 30) ).toHaveProperty('hour24', 0)
+		expect( compose24(12, 30) ).toHaveProperty('hour24', 12)
 	})
 });

--- a/src/helpers/__tests__/parse-time.js
+++ b/src/helpers/__tests__/parse-time.js
@@ -5,36 +5,42 @@ describe('helpers/parse-time', () => {
 		test('parses 12 hour format', () => {
 			expect( parse('8:32 am') ).toMatchObject({
 				hour: 8,
+				hour24: 8,
 				minute: 32,
 				meridiem: 'am'
 			})
 
 			expect( parse('12:32 am') ).toMatchObject({
 				hour: 12,
+				hour24: 0,
 				minute: 32,
 				meridiem: 'am'
 			})
 
 			expect( parse('12:32 pm') ).toMatchObject({
 				hour: 12,
+				hour24: 12,
 				minute: 32,
 				meridiem: 'pm'
 			})
 
 			expect( parse('8:32am') ).toMatchObject({
 				hour: 8,
+				hour24: 8,
 				minute: 32,
 				meridiem: 'am'
 			})
 
 			expect( parse('12:32pm') ).toMatchObject({
 				hour: 12,
+				hour24: 12,
 				minute: 32,
 				meridiem: 'pm'
 			})
 
 			expect( parse('0:32pm') ).toMatchObject({
 				hour: 12,
+				hour24: 12,
 				minute: 32,
 				meridiem: 'pm'
 			})
@@ -43,30 +49,35 @@ describe('helpers/parse-time', () => {
 		test('parses 24 hour format string', () => {
 			expect( parse('8:32') ).toMatchObject({
 				hour: 8,
+				hour24: 8,
 				minute: 32,
 				meridiem: 'am'
 			})
 
 			expect( parse('18:30') ).toMatchObject({
 				hour: 6,
+				hour24: 18,
 				minute: 30,
 				meridiem: 'pm'
 			})
 
 			expect( parse('0:30') ).toMatchObject({
 				hour: 12,
+				hour24: 0,
 				minute: 30,
 				meridiem: 'am'
 			})
 
 			expect( parse('12:00') ).toMatchObject({
 				hour: 12,
+				hour24: 12,
 				minute: 0,
 				meridiem: 'pm'
 			})
 
 			expect( parse('24:30') ).toMatchObject({
 				hour: 12,
+				hour24: 0,
 				minute: 30,
 				meridiem: 'am'
 			})
@@ -91,6 +102,7 @@ describe('helpers/parse-time', () => {
 				minute: 32
 			}) ).toMatchObject({
 				hour: 6,
+				hour24: 6,
 				minute: 32,
 				meridiem: 'am'
 			})
@@ -100,6 +112,7 @@ describe('helpers/parse-time', () => {
 				minute: 32
 			}) ).toMatchObject({
 				hour: 12,
+				hour24: 12,
 				minute: 32,
 				meridiem: 'pm'
 			})
@@ -109,6 +122,7 @@ describe('helpers/parse-time', () => {
 				minute: 32
 			}) ).toMatchObject({
 				hour: 2,
+				hour24: 14,
 				minute: 32,
 				meridiem: 'pm'
 			})
@@ -118,6 +132,7 @@ describe('helpers/parse-time', () => {
 				minute: 32
 			}) ).toMatchObject({
 				hour: 12,
+				hour24: 0,
 				minute: 32,
 				meridiem: 'am'
 			})
@@ -130,6 +145,7 @@ describe('helpers/parse-time', () => {
 				meridiem: 'am'
 			}) ).toMatchObject({
 				hour: 8,
+				hour24: 8,
 				minute: 32,
 				meridiem: 'am'
 			})
@@ -140,6 +156,7 @@ describe('helpers/parse-time', () => {
 				meridiem: 'pm'
 			}) ).toMatchObject({
 				hour: 2,
+				hour24: 14,
 				minute: 32,
 				meridiem: 'pm'
 			})
@@ -150,6 +167,7 @@ describe('helpers/parse-time', () => {
 				meridiem: 'am'
 			}) ).toMatchObject({
 				hour: 12,
+				hour24: 0,
 				minute: 32,
 				meridiem: 'am'
 			})

--- a/src/helpers/compose-time.js
+++ b/src/helpers/compose-time.js
@@ -1,5 +1,5 @@
 
-export default function composeTime(hour, minute, meridiem){
+export function composeTime(hour, minute, meridiem){
 	const paddedMinute = ('0' + minute).slice(-2)
 
 	let hour24 = hour;
@@ -15,6 +15,33 @@ export default function composeTime(hour, minute, meridiem){
 		formatted24: `${hour24}:${paddedMinute}`,
 		hour: hour,
 		hour24: hour24,
+		minute: minute,
+		meridiem: meridiem
+	}
+}
+
+export function composeTime24(hour24, minute) {
+	const paddedMinute = ('0' + minute).slice(-2)
+
+	let hour = hour24
+	let meridiem = 'am'
+	if (hour24 === 24 || hour24 === 0) {
+		hour = 12
+	}
+	else if (hour24 > 12) {
+		hour = hour24 - 12
+		meridiem = 'pm'
+	}
+	else if (hour24 === 12) {
+		meridiem = 'pm'
+	}
+
+	return {
+		formatted: `${hour}:${paddedMinute} ${meridiem}`,
+		formattedSimple: `${hour}:${paddedMinute}`,
+		formatted24: `${hour24}:${paddedMinute}`,
+		hour: hour,
+		hour24: hour24 < 24 ? hour24 : 0,
 		minute: minute,
 		meridiem: meridiem
 	}

--- a/src/helpers/data.js
+++ b/src/helpers/data.js
@@ -1,11 +1,18 @@
 
 const hours = Array.apply(null, {length: 12}).map((a, i) => (i + 1).toString())
+const hours24 = Array.apply(null, {length: 24}).map((a, i) => (i < 23 ? i + 1 : 0).toString())
 const minutes = Array.apply(null, {length: 60}).map((a, i) => i.toString())
 export const CLOCK_DATA = {
 	hour: {
 		numbers: hours,
 		dropdownOptions: hours,
 		increments: 12,
+		coarseMultiplier: 1
+	},
+	hour24: {
+		numbers: hours24,
+		dropdownOptions: hours24,
+		increments: 24,
 		coarseMultiplier: 1
 	},
 	minute: {

--- a/src/helpers/parse-time.js
+++ b/src/helpers/parse-time.js
@@ -10,7 +10,7 @@ const defaultTime = {
 // parse and normalize time to 12h format with meridiem
 export default function parseTime(time){
 	time = time || defaultTime;
-	
+
 	let hour;
 	let minute;
 	let meridiem = 'am'
@@ -53,8 +53,11 @@ export default function parseTime(time){
 		throw new Error('Time out of range');
 	}
 
+	let hour24 = meridiem === 'pm' && hour < 12 ? hour + 12 : meridiem === 'am' && hour === 12 ? 0 : hour
+
 	return {
 		hour,
+		hour24,
 		minute,
 		meridiem
 	}


### PR DESCRIPTION
Resolves issue #4

Default mode remains 12 hour am/pm mode.
However, `<TimeKeeper hourMode={'hour24'} />` results in the following:

<img alt="image of 24-hour usage" src="https://user-images.githubusercontent.com/38753527/55792794-b138fa00-5ac1-11e9-80fe-08a27ed419e9.png" width="300"/>

By shifting the outer ring by 1/2 increment, the angle calculated from the click or drag coordinates still uniquely identifies the selected hour. This way, the original implementation didn't need any drastic changes.

I also added some extra tests, and I included a 24 hour example in the docs intro page.