### PR TITLE
Update style.scss

### DIFF
--- a/docs/css/style.scss
+++ b/docs/css/style.scss
@@ -198,6 +198,7 @@ pre code {
 		font-style: italic;
 		font-weight: bold;
 		margin-right: 4px;
+		user-select: none;
 	}
 	.default {
 		border-radius: 2px;


### PR DESCRIPTION
Fixes #39 

Ensures the type is not selectable, and thus double-clicking on the prop name can be done without issues.

![2020-01-31_22-42-28](https://user-images.githubusercontent.com/9924643/73536861-14de4a80-447b-11ea-9b0f-63a095135b59.gif)
