### PR TITLE
[feature] Disable time range

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ TODO
 ## Installation
 
 ```shell
+$ yarn add react-timekeeper
+
+# or via npm
 $ npm install --save react-timekeeper
 ```
 
@@ -85,7 +88,7 @@ For full api and examples, see [API docs](https://catc.github.io/react-timekeepe
 ## Development
 1. Clone the repo
 3. `nvm use v12.16.0` (or anything >12+)
-2. `npm install`
+2. `yarn install`
     - may also need to install react since it's a peer dev: `yarn add -P react react-dom`
 3. `npm run docs:dev`
 4. Navigate to `localhost:3002`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For full api and examples, see [API docs](https://catc.github.io/react-timekeepe
 1. Clone the repo
 3. `nvm use v12.16.0` (or anything >12+)
 2. `npm install`
-  - may also need to install react since it's a peer dev: `yarn add -P react react-dom`
+    - may also need to install react since it's a peer dev: `yarn add -P react react-dom`
 3. `npm run docs:dev`
 4. Navigate to `localhost:3002`
 

--- a/docs/js/sections/api.tsx
+++ b/docs/js/sections/api.tsx
@@ -44,14 +44,15 @@ export default function Intro() {
 			{/* onchange */}
 			<h3 className="h3-api">
 				<code className="name">onChange</code>
-				<span className="accepts">(TimeOutput) => void</span>(default:{' '}
+				<span className="accepts">(TimeOutput) {`=>`} void</span>(default:{' '}
 				<code className="default">null</code>)
 			</h3>
 
 			<div className="api__description">
 				<Text>
-					Pass a function to be called when time is changed. Used to update time state in
-					parent component. Function called returns object with updated time.
+					Pass a function to be called when time is changed. Used to update time
+					state in parent component. Function called returns object with updated
+					time.
 				</Text>
 				<Code type={SYNTAX.js}>{`// TimeOutput
 {
@@ -85,8 +86,8 @@ export default function Intro() {
 
 			<div className="api__description">
 				<Text>
-					Changes clock unit from hour to minute after selecting an hour. Exists mainly to
-					provides a better user experience.
+					Changes clock unit from hour to minute after selecting an hour. Exists
+					mainly to provides a better user experience.
 				</Text>
 			</div>
 			{/* switchToMinuteOnHourDropdownSelect */}
@@ -98,7 +99,8 @@ export default function Intro() {
 
 			<div className="api__description">
 				<Text>
-					Changes clock unit from hour to minute after selecting an hour via the dropdown.
+					Changes clock unit from hour to minute after selecting an hour via the
+					dropdown.
 				</Text>
 			</div>
 
@@ -111,23 +113,25 @@ export default function Intro() {
 
 			<div className="api__description">
 				<Text>
-					Whether or not to trigger "Done" button click when the user selects minutes.
-					Similar to Google Keep functionality, where once the selects hour and minute,
-					the picker automatically closes.
+					Whether or not to trigger &quot;Done&quot; button click when the user
+					selects minutes. Similar to Google Keep functionality, where once the
+					selects hour and minute, the picker automatically closes.
 				</Text>
 			</div>
 
 			{/* coarseMinutes */}
 			<h3 className="h3-api">
 				<code className="name">coarseMinutes</code>
-				<span className="accepts">number</span>(default: <code className="default">5</code>)
+				<span className="accepts">number</span>(default:{' '}
+				<code className="default">5</code>)
 			</h3>
 
 			<div className="api__description">
 				<Text>
-					When roughly tapping minutes (ie: not dragging the cursor), rounds selected
-					number to increments (eg, tapping on 23 will round to 25). Is especially useful
-					for mobile. Set to 1 if you wish to avoid this feature.
+					When roughly tapping minutes (ie: not dragging the cursor), rounds
+					selected number to increments (eg, tapping on 23 will round to 25). Is
+					especially useful for mobile. Set to 1 if you wish to avoid this
+					feature.
 				</Text>
 			</div>
 
@@ -140,34 +144,52 @@ export default function Intro() {
 
 			<div className="api__description">
 				<Text>
-					Forces minutes to always round to <Code inline>coarseMinutes</Code> value - even
-					when dragging clockhand.
+					Forces minutes to always round to <Code inline>coarseMinutes</Code>{' '}
+					value - even when dragging clockhand.
 				</Text>
 			</div>
 
 			{/* onDoneClick */}
 			<h3 className="h3-api">
 				<code className="name">onDoneClick</code>
-				<span className="accepts">(TimeOutput, Event) => void</span>(default:{' '}
-				<code className="default">null</code>)
+				<span className="accepts">
+					(TimeOutput, Event) {`=>`} void
+				</span>(default: <code className="default">null</code>)
 			</h3>
 
 			<div className="api__description">
 				<Text>
-					Displays the "Done" button and calls function when button is clicked. Useful for
-					triggering some action on the parent component, like closing the timepicker.
+					Displays the &quot;Done&quot; button and calls function when button is
+					clicked. Useful for triggering some action on the parent component,
+					like closing the timepicker.
 				</Text>
 			</div>
 
 			{/* doneButton */}
 			<h3 className="h3-api">
 				<code className="name">doneButton</code>
-				<span className="accepts">(TimeOutput) => React.ReactNode</span>(default:{' '}
-				<code className="default">null</code>)
+				<span className="accepts">(TimeOutput) {`=>`} React.ReactNode</span>
+				(default: <code className="default">null</code>)
 			</h3>
 
 			<div className="api__description">
 				<Text>Custom done button as render props. See below for example.</Text>
+			</div>
+
+			{/* disabledTimeRange */}
+			<h3 className="h3-api">
+				<code className="name">disabledTimeRange</code>
+				<span className="accepts">{`{ from: string, to: string }`}</span>(default:{' '}
+				<code className="default">null</code>)
+			</h3>
+
+			<div className="api__description">
+				<Text>
+					Blocks off time range. From and to accepts 24hr formatted strings only
+					(eg: 16:20), regardless of 12h or 24h mode. Disabled times are
+					exclusive, eg: <code>{`{ from: 6:30, to: 8:40 }`}</code> allows
+					selecting 6:30 (but not 6:31+) and 8:40 (but not 8:39 or earlier).
+				</Text>
 			</div>
 
 			{/* custom styles */}

--- a/docs/js/sections/api.tsx
+++ b/docs/js/sections/api.tsx
@@ -50,7 +50,7 @@ export default function Intro() {
 
 			<div className="api__description">
 				<Text>
-					Pass a function to be called when time is changed. Used to store time state in
+					Pass a function to be called when time is changed. Used to update time state in
 					parent component. Function called returns object with updated time.
 				</Text>
 				<Code type={SYNTAX.js}>{`// TimeOutput

--- a/docs/js/sections/api.tsx
+++ b/docs/js/sections/api.tsx
@@ -62,7 +62,8 @@ export default function Intro() {
 	hour: 16,                // 24 hour
 	hour12: 4,
 	minute: 55,
-	meridiem: 'pm'				
+	meridiem: 'pm',
+	isValid: boolean,        // requires \`disabledTimeRange\`, false if time selected is blocked off
 }`}</Code>
 			</div>
 
@@ -189,6 +190,13 @@ export default function Intro() {
 					(eg: 16:20), regardless of 12h or 24h mode. Disabled times are
 					exclusive, eg: <code>{`{ from: 6:30, to: 8:40 }`}</code> allows
 					selecting 6:30 (but not 6:31+) and 8:40 (but not 8:39 or earlier).
+					<br />
+					<br />
+					Additional validation should be handled by your own app since there
+					are cases where user can select blocked off times, eg: if{' '}
+					<code>from: 6:30</code>, can select 5:45, then change hour to 6
+					resulting in 6:30 (which is blocked). For these cases, you can use{' '}
+					<code>TimeOutput.isValid</code> to determine if time is valid.
 				</Text>
 			</div>
 

--- a/docs/js/sections/examples.tsx
+++ b/docs/js/sections/examples.tsx
@@ -11,6 +11,7 @@ export default function Examples() {
 	const [time3, setTime3] = useState('12:45pm')
 	const [time4, setTime4] = useState('12:45pm')
 	const [time5, setTime5] = useState('5:30')
+	const [isValid5, setIsValid5] = useState(true)
 
 	return (
 		<section className="examples docs-section" id="examples">
@@ -205,11 +206,16 @@ function YourComponent(){
 					<div className="examples__example-3-timekeeper-wrapper">
 						<TimeKeeper
 							time={time5}
-							onChange={newTime => setTime5(newTime.formatted12)}
+							onChange={newTime => {
+								setIsValid5(newTime.isValid)
+								setTime5(newTime.formatted12)
+							}}
 							disabledTimeRange={{ from: '6:20', to: '20:45' }}
 						/>
 					</div>
-					<span className="examples__example-1-time">Time is {time5}</span>
+					<span className="examples__example-1-time">
+						Time is {time5}, valid time: {isValid5 ? '✅' : '❌'}
+					</span>
 				</div>
 
 				<Code type={SYNTAX.js}>{`import React from 'react';
@@ -217,15 +223,19 @@ import TimeKeeper from 'react-timekeeper';
 
 function YourComponent(){
 	const [time, setTime] = useState('12:34pm')
+	const [isValid, setIsValid] = useState(true)
 
 	return (
 		<div>
 			<TimeKeeper
 				time={time}
-				onChange={(newTime) => setTime(newTime.formatted12)}
+				onChange={(newTime) => {
+					setIsValid(newTime.isValid)
+					setTime(newTime.formatted12)
+				}}
 				disabledTimeRange={{ from: '6:20', to: '20:45' }}
 			/>
-			<span>Time is {time}</span>
+			<span>Time is {time5}, valid time: {isValid ? '✅' : '❌'}</span>
 		</div>
 	)
 }`}</Code>

--- a/docs/js/sections/examples.tsx
+++ b/docs/js/sections/examples.tsx
@@ -10,6 +10,7 @@ export default function Examples() {
 	const [displayExample2, setDisplayExample2] = useState(true)
 	const [time3, setTime3] = useState('12:45pm')
 	const [time4, setTime4] = useState('12:45pm')
+	const [time5, setTime5] = useState('5:30')
 
 	return (
 		<section className="examples docs-section" id="examples">
@@ -18,15 +19,15 @@ export default function Examples() {
 			{/* example 1 */}
 			<div className="examples__item">
 				<Text>
-					Basic example demonstrating passing in <code>time</code> and updating time on
-					parent component via <code>onChange</code> function.
+					Basic example demonstrating passing in <code>time</code> and updating
+					time on parent component via <code>onChange</code> function.
 				</Text>
 
 				<div className="examples__example-1">
 					<div className="examples__example-1-timekeeper-wrapper">
 						<TimeKeeper
 							time={time1}
-							onChange={(newTime) => setTime1(newTime.formatted12)}
+							onChange={newTime => setTime1(newTime.formatted12)}
 						/>
 					</div>
 					<span className="examples__example-1-time">Time is {time1}</span>
@@ -53,8 +54,8 @@ function YourComponent(){
 			{/* example 2 */}
 			<div className="examples__item">
 				<Text>
-					Change unit to minutes after selecting hour, and close time picker on clicking
-					"done" button.
+					Change unit to minutes after selecting hour, and close time picker on
+					clicking &quot;done&quot; button.
 				</Text>
 
 				<div className="examples__example-2">
@@ -62,7 +63,7 @@ function YourComponent(){
 						<div className="examples__example-2-timekeeper-wrapper">
 							<TimeKeeper
 								time={time2}
-								onChange={(newTime) => setTime2(newTime.formatted12)}
+								onChange={newTime => setTime2(newTime.formatted12)}
 								onDoneClick={() => setDisplayExample2(false)}
 								switchToMinuteOnHourSelect
 							/>
@@ -104,7 +105,6 @@ function YourComponent(){
 			}
 		</div>
 	)
-
 }`}</Code>
 			</div>
 
@@ -116,7 +116,7 @@ function YourComponent(){
 					<div className="examples__example-3-timekeeper-wrapper">
 						<TimeKeeper
 							time={time3}
-							onChange={(newTime) => setTime3(newTime.formatted12)}
+							onChange={newTime => setTime3(newTime.formatted12)}
 							switchToMinuteOnHourSelect
 							hour24Mode
 							forceCoarseMinutes
@@ -144,7 +144,6 @@ function YourComponent(){
 			<span>Time is {time}</span>
 		</div>
 	)
-		
 }`}</Code>
 			</div>
 
@@ -156,11 +155,13 @@ function YourComponent(){
 					<div className="examples__example-3-timekeeper-wrapper">
 						<TimeKeeper
 							time={time4}
-							onChange={(newTime) => setTime4(newTime.formatted12)}
-							doneButton={(newTime) => (
+							onChange={newTime => setTime4(newTime.formatted12)}
+							doneButton={newTime => (
 								<div
 									style={{ textAlign: 'center', padding: '10px 0' }}
-									onClick={() => alert('new time is now', newTime.formatted12)}
+									onClick={() =>
+										alert('new time is now ' + newTime.formatted12)
+									}
 								>
 									Close
 								</div>
@@ -193,7 +194,40 @@ function YourComponent(){
 			<span>Time is {time}</span>
 		</div>
 	)
-		
+}`}</Code>
+			</div>
+
+			{/* example 5 */}
+			<div className="examples__item foo">
+				<Text>Disabled time range</Text>
+
+				<div className="examples__example-3">
+					<div className="examples__example-3-timekeeper-wrapper">
+						<TimeKeeper
+							time={time5}
+							onChange={newTime => setTime5(newTime.formatted12)}
+							disabledTimeRange={{ from: '6:20', to: '20:45' }}
+						/>
+					</div>
+					<span className="examples__example-1-time">Time is {time5}</span>
+				</div>
+
+				<Code type={SYNTAX.js}>{`import React from 'react';
+import TimeKeeper from 'react-timekeeper';
+
+function YourComponent(){
+	const [time, setTime] = useState('12:34pm')
+
+	return (
+		<div>
+			<TimeKeeper
+				time={time}
+				onChange={(newTime) => setTime(newTime.formatted12)}
+				disabledTimeRange={{ from: '6:20', to: '20:45' }}
+			/>
+			<span>Time is {time}</span>
+		</div>
+	)
 }`}</Code>
 			</div>
 		</section>

--- a/docs/js/sections/other.tsx
+++ b/docs/js/sections/other.tsx
@@ -11,8 +11,8 @@ export default function Other() {
 			<div className="examples__item">
 				<Text>There are two ways of overriding/customizing styles:</Text>
 				<Text>
-					<strong>CSS variables:</strong> for changing basic styling - mainly text colors,
-					background colors, fonts, etc. See{' '}
+					<strong>CSS variables:</strong> for changing basic styling - mainly
+					text colors, background colors, fonts, etc. See{' '}
 					<Link
 						samePage
 						href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties"
@@ -68,6 +68,7 @@ var(--hand-minute-circle, #ade2fb); // minutes only, dot between intervals
 
 // numbers
 var(--numbers-text-color, #999);
+var(--numbers-text-color-disabled, #ddd);
 var(--numbers-font-size-reg, 16px); // 12h mode only
 var(--numbers-font-size-inner, 15px); // 24h mode only
 var(--numbers-font-size-outer, 13px); // 24h mode only
@@ -90,8 +91,9 @@ var(--done-font-weight, 500);
 
 				<hr />
 				<Text>
-					<strong>Higher CSS specificity:</strong> for more control over css, each element
-					has a class name you can override properties with 1 level of specifity.
+					<strong>Higher CSS specificity:</strong> for more control over css,
+					each element has a class name you can override properties with 1 level
+					of specifity.
 				</Text>
 				<Code type={SYNTAX.css}>
 					{`// won't work because emotion will override your styles

--- a/docs/js/sections/other.tsx
+++ b/docs/js/sections/other.tsx
@@ -54,6 +54,7 @@ var(--top-meridiem-color, #8C8C8C)
 var(--dropdown-border, 1px solid #f4f4f4)
 var(--dropdown-shadow, 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24))
 var(--dropdown-text-color, #8c8c8c)
+var(--dropdown-text-color-disabled, #ddd)
 var(--dropdown-hover-bg, #EAF8FF)
 
 // clock wrapper
@@ -72,7 +73,6 @@ var(--numbers-text-color-disabled, #ddd);
 var(--numbers-font-size-reg, 16px); // 12h mode only
 var(--numbers-font-size-inner, 15px); // 24h mode only
 var(--numbers-font-size-outer, 13px); // 24h mode only
-
 
 // meridiem buttons
 var(--meridiem-bg-color, white);

--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -32,7 +32,7 @@ interface Props {
 export default function ClockWrapper({ clockEl }: Props) {
 	const firstRun = useRef(true)
 	const { hour24Mode } = useConfig()
-	const { mode, time } = useTimekeeperState()
+	const { mode, time, meridiem, disabledTimeRangeValidator } = useTimekeeperState()
 
 	const transitions = useTransition(mode, {
 		unique: true,
@@ -62,12 +62,18 @@ export default function ClockWrapper({ clockEl }: Props) {
 		<div className="react-timekeeper__clock" css={style} ref={clockEl}>
 			{transitions((anim, currentMode) =>
 				isMinuteMode(currentMode) ? (
-					<MinuteNumbers anim={anim} />
+					<MinuteNumbers
+						anim={anim}
+						disabledTimeRangeValidator={disabledTimeRangeValidator}
+						hour={time.hour}
+					/>
 				) : (
 					<HourNumbers
 						anim={anim}
 						mode={currentMode as MODE.HOURS_12 | MODE.HOURS_24}
 						hour24Mode={hour24Mode}
+						disabledTimeRangeValidator={disabledTimeRangeValidator}
+						meridiem={meridiem}
 					/>
 				),
 			)}

--- a/src/components/ClockHand.tsx
+++ b/src/components/ClockHand.tsx
@@ -73,7 +73,7 @@ export default function ClockHand({ mode, time }: Props) {
 				position: circlePosition,
 			})
 		} else if (!isSameTime(prevState.current.time, time)) {
-			// time changed, no animation necessary - just update clockhand
+			// time changed, no animation necessary - just update clockhand (without animation)
 			prevState.current.time = time
 			dragCount.current++
 

--- a/src/components/ClockWrapper.tsx
+++ b/src/components/ClockWrapper.tsx
@@ -7,7 +7,7 @@ import Meridiems from './Meridiems'
 import style from './styles/clock-wrapper'
 import useClockEvents from '../hooks/useClockEvents'
 import { MODE, CLOCK_VALUES } from '../helpers/constants'
-import { isMinuteMode } from '../helpers/utils'
+import { isHourMode, isMinuteMode } from '../helpers/utils'
 import useTimekeeperState from '../hooks/useStateContext'
 
 export default function ClockWrapper() {
@@ -59,7 +59,9 @@ export default function ClockWrapper() {
 				- if 12 clicked between 12 and 1, results in 0
 				- if 12 clicked between 11 and 12, results in 12
 			*/
-			selected = selected % 12
+			if (isHourMode(mode)) {
+				selected = selected % 12
+			}
 			if (mode === MODE.HOURS_24 && config.hour24Mode) {
 				if (!isInnerClick) {
 					selected += 12

--- a/src/components/ClockWrapper.tsx
+++ b/src/components/ClockWrapper.tsx
@@ -54,17 +54,20 @@ export default function ClockWrapper() {
 			const val = (angle / 360) * totalIncrements
 			let selected = Math.round(val / minIncrement) * minIncrement
 
+			/*
+				normalize value, acounts for angle that 12 is selected at, eg:
+				- if 12 clicked between 12 and 1, results in 0
+				- if 12 clicked between 11 and 12, results in 12
+			*/
+			selected = selected % 12
 			if (mode === MODE.HOURS_24 && config.hour24Mode) {
+				if (!isInnerClick) {
+					selected += 12
+				}
 				// fixes 12pm and midnight, both angle -> selected return 0
 				// for midnight need a final selected of 0, and for noon need 12
-				if (!isInnerClick && selected !== 0) {
-					selected += 12
-				} else if (isInnerClick && selected === 0) {
-					selected += 12
-				}
-				if (selected === 24) {
-					selected = 0
-				}
+				if (selected === 12) selected = 0
+				else if (selected === 0) selected = 12
 			}
 
 			// update time officially on timekeeper

--- a/src/components/Numbers.tsx
+++ b/src/components/Numbers.tsx
@@ -76,13 +76,11 @@ function Hours({
 			{numbersOuter.map(({ value, enabled }, i) => {
 				return (
 					<animated.span
-						css={numbersStyle({ hour24Mode })}
+						css={numbersStyle({ hour24Mode, enabled })}
 						key={value}
 						data-testid="number_hour_outer"
 						style={{
 							transform: translateOuter.to(v => transform(i + 1, v)),
-							opacity: enabled ? 1 : 0.2,
-							transition: 'opacity 0.2s ease-out',
 						}}
 					>
 						{value}
@@ -94,13 +92,11 @@ function Hours({
 				numbersInner!.map(({ value, enabled }, i) => {
 					return (
 						<animated.span
-							css={numbersStyle({ hour24Mode, inner: true })}
+							css={numbersStyle({ hour24Mode, inner: true, enabled })}
 							key={value}
 							data-testid="number_hour_inner"
 							style={{
 								transform: translateInner.to(v => transform(i + 1, v)),
-								opacity: enabled ? 1 : 0.2,
-								transition: 'opacity 0.2s ease-out',
 							}}
 						>
 							{value}
@@ -140,13 +136,11 @@ function Minutes({ anim, hour, disabledTimeRangeValidator }: MinuteProps) {
 			{minutes.map(({ value, enabled }, i) => {
 				return (
 					<animated.span
-						css={numbersStyle({})}
+						css={numbersStyle({ enabled })}
 						key={value}
 						data-testid="number_minute"
 						style={{
 							transform: translate.to(v => transform(i + 1, v)),
-							opacity: enabled ? 1 : 0.2,
-							transition: 'opacity 0.2s ease-out',
 						}}
 					>
 						{value}

--- a/src/components/Numbers.tsx
+++ b/src/components/Numbers.tsx
@@ -1,11 +1,13 @@
-import React, { memo } from 'react'
+import React, { memo, useMemo } from 'react'
 import { animated, SpringValue } from 'react-spring'
+import DisabledTimeRange from '../helpers/disable-time'
 
-import { MINUTES, CLOCK_VALUES, MODE } from '../helpers/constants'
+import { MINUTES, CLOCK_VALUES, MODE, MERIDIEM } from '../helpers/constants'
 import { transform } from '../helpers/math'
 import { numbersStyle, numbersWrapperStyle } from './styles/numbers'
 
-interface MinuteProps {
+interface CommonProps {
+	disabledTimeRangeValidator: DisabledTimeRange | null
 	anim: {
 		opacity: SpringValue<number>
 		translate: SpringValue<number>
@@ -13,18 +15,57 @@ interface MinuteProps {
 	}
 }
 
-interface HourProps extends MinuteProps {
+interface MinuteProps extends CommonProps {
+	hour: number
+}
+
+interface HourProps extends CommonProps {
 	mode: MODE.HOURS_12 | MODE.HOURS_24
 	hour24Mode: boolean
+	meridiem: MERIDIEM
 }
 
 /*
 	can memoize components since `anim` object doesn't actually change
 */
 
-function hours({ anim, mode, hour24Mode }: HourProps) {
+function Hours({
+	anim,
+	mode,
+	hour24Mode,
+	disabledTimeRangeValidator,
+	meridiem,
+}: HourProps) {
 	const { opacity, translate: translateOuter, translateInner } = anim
-	const { numbers: numbersOuter, numbersInner } = CLOCK_VALUES[mode]
+	const { numbersOuter, numbersInner } = useMemo(() => {
+		const { numbers: numbersOuter, numbersInner } = CLOCK_VALUES[mode]
+		let normalizeOuterIndex: (i: number) => number
+		// for 12h mode, 12 is actually index 0
+		if (mode === MODE.HOURS_12 && meridiem === 'am') {
+			normalizeOuterIndex = i => (i % 11) + 1
+		} else if (mode === MODE.HOURS_12 && meridiem === 'pm') {
+			normalizeOuterIndex = i => (i % 11) + 13
+		} else {
+			// for 24h mode, 12/24 is last index for ring
+			normalizeOuterIndex = i => (i % 12) + 13
+		}
+
+		const normalizeInnerIndex = (i: number) => (i % 12) + 1
+		return {
+			numbersOuter: numbersOuter.map((value, i) => ({
+				value,
+				enabled:
+					disabledTimeRangeValidator?.validateHour(normalizeOuterIndex(i)) ??
+					true,
+			})),
+			numbersInner: numbersInner?.map((value, i) => ({
+				value,
+				enabled:
+					disabledTimeRangeValidator?.validateHour(normalizeInnerIndex(i)) ??
+					true,
+			})),
+		}
+	}, [mode, meridiem, disabledTimeRangeValidator])
 
 	return (
 		<animated.div
@@ -32,33 +73,37 @@ function hours({ anim, mode, hour24Mode }: HourProps) {
 			css={numbersWrapperStyle}
 			className="react-timekeeper__clock-hours"
 		>
-			{numbersOuter.map((val, i) => {
+			{numbersOuter.map(({ value, enabled }, i) => {
 				return (
 					<animated.span
 						css={numbersStyle({ hour24Mode })}
-						key={val}
+						key={value}
 						data-testid="number_hour_outer"
 						style={{
 							transform: translateOuter.to(v => transform(i + 1, v)),
+							opacity: enabled ? 1 : 0.2,
+							transition: 'opacity 0.2s ease-out',
 						}}
 					>
-						{val}
+						{value}
 					</animated.span>
 				)
 			})}
 
 			{hour24Mode &&
-				numbersInner!.map((val, i) => {
+				numbersInner!.map(({ value, enabled }, i) => {
 					return (
 						<animated.span
 							css={numbersStyle({ hour24Mode, inner: true })}
-							key={val}
+							key={value}
 							data-testid="number_hour_inner"
 							style={{
 								transform: translateInner.to(v => transform(i + 1, v)),
+								opacity: enabled ? 1 : 0.2,
+								transition: 'opacity 0.2s ease-out',
 							}}
 						>
-							{val}
+							{value}
 						</animated.span>
 					)
 				})}
@@ -66,29 +111,45 @@ function hours({ anim, mode, hour24Mode }: HourProps) {
 	)
 }
 
-export const HourNumbers = memo(hours, (prev, next) => {
-	return prev.mode === next.mode && prev.hour24Mode === next.hour24Mode
+export const HourNumbers = memo(Hours, (prev, next) => {
+	return (
+		prev.mode === next.mode &&
+		prev.hour24Mode === next.hour24Mode &&
+		prev.meridiem === next.meridiem &&
+		prev.disabledTimeRangeValidator === next.disabledTimeRangeValidator
+	)
 })
 
-function minutes({ anim }: MinuteProps) {
+function Minutes({ anim, hour, disabledTimeRangeValidator }: MinuteProps) {
 	const { opacity, translate } = anim
+	const minutes = useMemo(() => {
+		return MINUTES.map(value => ({
+			value,
+			enabled:
+				disabledTimeRangeValidator?.validateMinute(hour, parseInt(value, 10)) ??
+				true,
+		}))
+	}, [disabledTimeRangeValidator, hour])
+
 	return (
 		<animated.div
 			style={{ opacity }}
 			css={numbersWrapperStyle}
 			className="react-timekeeper__clock-minutes"
 		>
-			{MINUTES.map((val, i) => {
+			{minutes.map(({ value, enabled }, i) => {
 				return (
 					<animated.span
 						css={numbersStyle({})}
-						key={val}
+						key={value}
 						data-testid="number_minute"
 						style={{
 							transform: translate.to(v => transform(i + 1, v)),
+							opacity: enabled ? 1 : 0.2,
+							transition: 'opacity 0.2s ease-out',
 						}}
 					>
-						{val}
+						{value}
 					</animated.span>
 				)
 			})}
@@ -96,6 +157,9 @@ function minutes({ anim }: MinuteProps) {
 	)
 }
 
-export const MinuteNumbers = memo(minutes, () => {
-	return true
+export const MinuteNumbers = memo(Minutes, (prev, next) => {
+	return (
+		prev.disabledTimeRangeValidator === next.disabledTimeRangeValidator &&
+		prev.hour === next.hour
+	)
 })

--- a/src/components/TimeDropdown.tsx
+++ b/src/components/TimeDropdown.tsx
@@ -17,8 +17,8 @@ let scrollbarWidth: null | number = null
 type ElementLiRef = MutableRefObject<HTMLLIElement | null>
 
 export default function TimeDropdown({ close }: Props) {
-	const { hour24Mode, switchToMinuteOnHourDropdownSelect } = useConfig()
-	const { updateTime, mode, time, setMode } = useTimekeeperState()
+	const { hour24Mode } = useConfig()
+	const { updateTimeValue, mode, time } = useTimekeeperState()
 
 	const container: ElementRef = useRef(null)
 	const selectedOption: ElementLiRef = useRef(null)
@@ -73,12 +73,7 @@ export default function TimeDropdown({ close }: Props) {
 		if (mode === MODE.HOURS_12 && parsed === 12) {
 			parsed = 0
 		}
-		updateTime(parsed)
-
-		// handle any unit autochanges on hour select
-		if (switchToMinuteOnHourDropdownSelect && isHourMode(mode)) {
-			setMode(MODE.MINUTES)
-		}
+		updateTimeValue(parsed, { type: 'dropdown' })
 		close()
 	}
 

--- a/src/components/TimeDropdown.tsx
+++ b/src/components/TimeDropdown.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useRef, MutableRefObject } from 'react'
+import React, { useCallback, useEffect, useRef, MutableRefObject, useMemo } from 'react'
 
 import * as styles from './styles/time-dropdown'
 import useConfig from '../hooks/useConfigContext'
 import { getScrollBarWidth } from '../helpers/dom'
-import { getNormalizedTimeValue, isHourMode } from '../helpers/utils'
+import { getNormalizedTimeValue } from '../helpers/utils'
 import { ElementRef } from '../helpers/types'
 import { CLOCK_VALUES, MODE } from '../helpers/constants'
 import useTimekeeperState from '../hooks/useStateContext'
@@ -18,12 +18,42 @@ type ElementLiRef = MutableRefObject<HTMLLIElement | null>
 
 export default function TimeDropdown({ close }: Props) {
 	const { hour24Mode } = useConfig()
-	const { updateTimeValue, mode, time } = useTimekeeperState()
+	const { updateTimeValue, mode, time, meridiem, disabledTimeRangeValidator } =
+		useTimekeeperState()
 
 	const container: ElementRef = useRef(null)
 	const selectedOption: ElementLiRef = useRef(null)
 
-	const options = CLOCK_VALUES[mode].dropdown
+	const options = useMemo(() => {
+		const o = CLOCK_VALUES[mode].dropdown
+
+		let validator: (value: string, i: number) => boolean = () => true
+		if (disabledTimeRangeValidator) {
+			if (mode === MODE.HOURS_12) {
+				if (meridiem === 'am') {
+					validator = (_, i) =>
+						disabledTimeRangeValidator.validateHour((i + 1) % 12)
+				} else {
+					validator = (_, i) => {
+						// account for last number (12) which should be first (noon, 1pm, ...) in 24h format
+						const num = i === 11 ? 12 : i + 13
+						return disabledTimeRangeValidator.validateHour(num)
+					}
+				}
+			} else if (mode === MODE.HOURS_24) {
+				validator = (_, i) =>
+					disabledTimeRangeValidator.validateHour((i + 1) % 24)
+			} else if (mode === MODE.MINUTES) {
+				validator = v =>
+					disabledTimeRangeValidator.validateMinute(time.hour, parseInt(v, 10))
+			}
+		}
+		return o.map((value, i) => ({
+			value,
+			enabled: validator(value, i),
+		}))
+	}, [mode, disabledTimeRangeValidator, meridiem, time.hour])
+
 	const selected = getNormalizedTimeValue(mode, time).toString()
 
 	function disableBodyScroll() {
@@ -68,7 +98,9 @@ export default function TimeDropdown({ close }: Props) {
 	}, [elsewhereClick])
 
 	// select a value
-	function select(val: string) {
+	function select(val: string, enabled: boolean) {
+		if (!enabled) return
+
 		let parsed = parseInt(val, 10)
 		if (mode === MODE.HOURS_12 && parsed === 12) {
 			parsed = 0
@@ -87,8 +119,8 @@ export default function TimeDropdown({ close }: Props) {
 			data-testid="time-dropdown"
 		>
 			<ul css={styles.options} className="react-timekeeper__dropdown-numbers">
-				{options.map(o => {
-					const isSelected = selected === o
+				{options.map(({ value, enabled }) => {
+					const isSelected = selected === value
 					return (
 						<li
 							ref={el => (isSelected ? (selectedOption.current = el) : '')}
@@ -97,12 +129,12 @@ export default function TimeDropdown({ close }: Props) {
 									? 'react-timekeeper__dropdown-number--active'
 									: ''
 							}`}
-							css={styles.option(isSelected)}
-							key={o}
-							onClick={() => select(o)}
+							css={styles.option({ active: isSelected, enabled })}
+							key={value}
+							onClick={() => select(value, enabled)}
 							data-testid="time-dropdown_number"
 						>
-							{o}
+							{value}
 						</li>
 					)
 				})}

--- a/src/components/TimeKeeperContainer.tsx
+++ b/src/components/TimeKeeperContainer.tsx
@@ -7,6 +7,7 @@ import { TimeInput, ChangeTimeFn } from '../helpers/types'
 export interface Props extends ConfigProps {
 	time?: TimeInput
 	onChange?: ChangeTimeFn
+	disabledTimeRange?: null | { from: string; to: string }
 }
 
 export default function TimepickerWithConfig({
@@ -21,6 +22,7 @@ export default function TimepickerWithConfig({
 	hour24Mode,
 	onDoneClick,
 	doneButton,
+	disabledTimeRange,
 }: Props) {
 	return (
 		<ConfigProvider
@@ -33,7 +35,11 @@ export default function TimepickerWithConfig({
 			onDoneClick={onDoneClick}
 			doneButton={doneButton}
 		>
-			<StateProvider onChange={onChange} time={time}>
+			<StateProvider
+				onChange={onChange}
+				time={time}
+				disabledTimeRange={disabledTimeRange}
+			>
 				<TimeKeeper />
 			</StateProvider>
 		</ConfigProvider>

--- a/src/components/__tests__/events.test.tsx
+++ b/src/components/__tests__/events.test.tsx
@@ -9,6 +9,10 @@ import {
 	MINUTE_7,
 	MINUTE_23,
 	MINUTE_59,
+	MIDNIGHT_OUTER_FROM_LEFT,
+	MIDNIGHT_OUTER_FROM_RIGHT,
+	MIDNIGHT_INNER_FROM_LEFT,
+	MIDNIGHT_INNER_FROM_RIGHT,
 } from './helpers/coords'
 import { Props as TimekeeperProps } from '../TimeKeeperContainer'
 
@@ -43,19 +47,15 @@ describe('handles events correctly', () => {
 		it('handles outer click on "3" during 12h mode', () => {
 			testHours(HOUR_3_OUTER, '3:20')
 		})
-
 		it('handles inner click on "3" during 12h mode', () => {
 			testHours(HOUR_3_INNER, '3:20')
 		})
-
 		it('handles outer click on "12" during 12h mode', () => {
 			testHours(HOUR_24_OUTER, '0:20')
 		})
-
 		it('handles inner click on "12" during 12h mode', () => {
 			testHours(HOUR_12_INNER, '0:20')
 		})
-
 		it('handles outer click on "3" during 24h mode', () => {
 			testHours(HOUR_3_OUTER, '15:20', true)
 		})
@@ -67,6 +67,26 @@ describe('handles events correctly', () => {
 		})
 		it('handles inner click on "12" during 24h mode', () => {
 			testHours(HOUR_12_INNER, '12:20', true)
+		})
+
+		// test midnight/noon values from angles on left and right
+		it('handles click on "12" from left during 12h mode', () => {
+			testHours(MIDNIGHT_OUTER_FROM_LEFT, '0:20')
+		})
+		it('handles click on "12" from right during 12h mode', () => {
+			testHours(MIDNIGHT_OUTER_FROM_RIGHT, '0:20')
+		})
+		it('handles outer click on "12" from left during 24h mode', () => {
+			testHours(MIDNIGHT_OUTER_FROM_LEFT, '0:20', true)
+		})
+		it('handles outer click on "12" from right during 24h mode', () => {
+			testHours(MIDNIGHT_OUTER_FROM_RIGHT, '0:20', true)
+		})
+		it('handles inner click on "12" from right during 24h mode', () => {
+			testHours(MIDNIGHT_INNER_FROM_LEFT, '12:20', true)
+		})
+		it('handles inner click on "12" from right during 24h mode', () => {
+			testHours(MIDNIGHT_INNER_FROM_RIGHT, '12:20', true)
 		})
 	})
 

--- a/src/components/__tests__/events.test.tsx
+++ b/src/components/__tests__/events.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, RenderResult, act, getAllByTestId } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 import {
 	renderTK,
 	mockAnimations,
@@ -189,6 +189,38 @@ describe('handles events correctly', () => {
 				expect(onChange).toHaveBeenCalledWith(
 					expect.objectContaining({
 						formatted24: '6:10',
+					}),
+				)
+			})
+		})
+
+		// TimeOutput.isValid
+		describe('supports TimeOutput.isValid', () => {
+			it('handles isValid', () => {
+				const { wrapper, onChange } = renderTK({
+					time: { hour: 5, minute: 45 },
+					disabledTimeRange: { from: '6:20', to: '17:35' },
+				})
+				const { getByTestId } = wrapper
+
+				// 6:45 is invalid
+				clickOnPoint(wrapper, generateCoords(6, 'hour'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '6:45',
+						isValid: false,
+					}),
+				)
+
+				// change minutes to something valid
+				fireEvent.click(getByTestId('topbar_minute'))
+				fireEvent.click(getByTestId('topbar_minute'))
+				onChange.mockClear()
+				clickOnPoint(wrapper, generateCoords(15, 'minute'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '6:15',
+						isValid: true,
 					}),
 				)
 			})

--- a/src/components/__tests__/events.test.tsx
+++ b/src/components/__tests__/events.test.tsx
@@ -1,5 +1,11 @@
 import { fireEvent, RenderResult, act, getAllByTestId } from '@testing-library/react'
-import { renderTK, mockAnimations, clickOnPoint, changeToMinutes } from './helpers/dom'
+import {
+	renderTK,
+	mockAnimations,
+	clickOnPoint,
+	changeToMinutes,
+	changeMeridiem,
+} from './helpers/dom'
 import {
 	HOUR_12_INNER,
 	HOUR_24_OUTER,
@@ -13,6 +19,7 @@ import {
 	MIDNIGHT_OUTER_FROM_RIGHT,
 	MIDNIGHT_INNER_FROM_LEFT,
 	MIDNIGHT_INNER_FROM_RIGHT,
+	generateCoords,
 } from './helpers/coords'
 import { Props as TimekeeperProps } from '../TimeKeeperContainer'
 
@@ -28,10 +35,14 @@ describe('handles events correctly', () => {
 	})
 
 	describe('updates hours', () => {
-		function testHours(coords: Coords, expectedTime: string, is24hrMode = false) {
+		function testHours(
+			coords: Coords,
+			expectedTime: string,
+			opts: Partial<TimekeeperProps> = {},
+		) {
 			const { wrapper, onChange } = renderTK({
 				time: { hour: 5, minute: 20 },
-				hour24Mode: is24hrMode,
+				...opts,
 			})
 
 			clickOnPoint(wrapper, coords)
@@ -57,16 +68,16 @@ describe('handles events correctly', () => {
 			testHours(HOUR_12_INNER, '0:20')
 		})
 		it('handles outer click on "3" during 24h mode', () => {
-			testHours(HOUR_3_OUTER, '15:20', true)
+			testHours(HOUR_3_OUTER, '15:20', { hour24Mode: true })
 		})
 		it('handles inner click on "3" during 24h mode', () => {
-			testHours(HOUR_3_INNER, '3:20', true)
+			testHours(HOUR_3_INNER, '3:20', { hour24Mode: true })
 		})
 		it('handles outer click on "12" during 24h mode', () => {
-			testHours(HOUR_24_OUTER, '0:20', true)
+			testHours(HOUR_24_OUTER, '0:20', { hour24Mode: true })
 		})
 		it('handles inner click on "12" during 24h mode', () => {
-			testHours(HOUR_12_INNER, '12:20', true)
+			testHours(HOUR_12_INNER, '12:20', { hour24Mode: true })
 		})
 
 		// test midnight/noon values from angles on left and right
@@ -77,16 +88,110 @@ describe('handles events correctly', () => {
 			testHours(MIDNIGHT_OUTER_FROM_RIGHT, '0:20')
 		})
 		it('handles outer click on "12" from left during 24h mode', () => {
-			testHours(MIDNIGHT_OUTER_FROM_LEFT, '0:20', true)
+			testHours(MIDNIGHT_OUTER_FROM_LEFT, '0:20', { hour24Mode: true })
 		})
 		it('handles outer click on "12" from right during 24h mode', () => {
-			testHours(MIDNIGHT_OUTER_FROM_RIGHT, '0:20', true)
+			testHours(MIDNIGHT_OUTER_FROM_RIGHT, '0:20', { hour24Mode: true })
 		})
 		it('handles inner click on "12" from right during 24h mode', () => {
-			testHours(MIDNIGHT_INNER_FROM_LEFT, '12:20', true)
+			testHours(MIDNIGHT_INNER_FROM_LEFT, '12:20', { hour24Mode: true })
 		})
 		it('handles inner click on "12" from right during 24h mode', () => {
-			testHours(MIDNIGHT_INNER_FROM_RIGHT, '12:20', true)
+			testHours(MIDNIGHT_INNER_FROM_RIGHT, '12:20', { hour24Mode: true })
+		})
+
+		// blocked off hours
+		describe('blocked time range', () => {
+			it('handles blocked off times during 12h mode', () => {
+				const { wrapper, onChange } = renderTK({
+					time: { hour: 5, minute: 20 },
+					disabledTimeRange: { from: '6:20', to: '17:35' },
+				})
+				const { getByTestId } = wrapper
+
+				// hours
+				clickOnPoint(wrapper, generateCoords(8, 'hour'))
+				expect(onChange).not.toBeCalled()
+
+				clickOnPoint(wrapper, generateCoords(3, 'hour'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '3:20',
+					}),
+				)
+
+				// test pm meridiem
+				fireEvent.click(getByTestId('meridiem_pm'))
+				onChange.mockClear()
+
+				clickOnPoint(wrapper, generateCoords(3, 'hour'))
+				expect(onChange).not.toBeCalled()
+
+				clickOnPoint(wrapper, generateCoords(8, 'hour'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '20:20',
+					}),
+				)
+
+				// minutes
+				// select hour with disabled minutes
+				clickOnPoint(wrapper, generateCoords(5, 'hour'))
+				changeToMinutes(wrapper)
+
+				onChange.mockClear()
+				clickOnPoint(wrapper, generateCoords(15, 'minute'))
+				expect(onChange).not.toBeCalled()
+				clickOnPoint(wrapper, generateCoords(40, 'minute'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '17:40',
+					}),
+				)
+			})
+
+			it('handles blocked off times during 24h mode', () => {
+				const { wrapper, onChange } = renderTK({
+					time: { hour: 5, minute: 20 },
+					hour24Mode: true,
+					disabledTimeRange: { from: '6:20', to: '17:35' },
+				})
+
+				clickOnPoint(wrapper, generateCoords(8, 'hour'))
+				expect(onChange).not.toBeCalled()
+				clickOnPoint(wrapper, generateCoords(20, 'hour'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '20:20',
+					}),
+				)
+
+				// test midnight
+				onChange.mockClear()
+				clickOnPoint(wrapper, generateCoords(12, 'hour'))
+				expect(onChange).not.toBeCalled()
+				clickOnPoint(wrapper, generateCoords(24, 'hour'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '0:20',
+					}),
+				)
+
+				// test minutes
+				// select hour with disabled minutes
+				clickOnPoint(wrapper, generateCoords(6, 'hour'))
+				changeToMinutes(wrapper)
+
+				onChange.mockClear()
+				clickOnPoint(wrapper, generateCoords(40, 'minute'))
+				expect(onChange).not.toBeCalled()
+				clickOnPoint(wrapper, generateCoords(10, 'minute'))
+				expect(onChange).toHaveBeenCalledWith(
+					expect.objectContaining({
+						formatted24: '6:10',
+					}),
+				)
+			})
 		})
 	})
 
@@ -226,6 +331,111 @@ describe('handles events correctly', () => {
 					minute: 32,
 				}),
 			)
+		})
+
+		describe('supports blocked times', () => {
+			function renderHourDropdown(opts: TimekeeperProps = {}) {
+				const { wrapper, onChange } = renderTK(opts)
+				const { getByTestId, getAllByTestId } = wrapper
+
+				// open dropdown
+				fireEvent.click(getByTestId('topbar_hour'))
+
+				const numbers = getAllByTestId('time-dropdown_number')
+
+				return { numbers, onChange, wrapper }
+			}
+
+			it('handles blocked off times during 12h mode', () => {
+				const { onChange, numbers, wrapper } = renderHourDropdown({
+					time: { hour: 5, minute: 20 },
+					disabledTimeRange: { from: '6:20', to: '17:35' },
+				})
+				const { getByTestId, getAllByTestId } = wrapper
+
+				fireEvent.click(numbers[6]) // click 7
+				fireEvent.click(numbers[10]) // click 11
+				expect(onChange).not.toBeCalled()
+
+				// 12 should be clickable (since 12am is 0)
+				fireEvent.click(numbers[11])
+				expect(onChange).toBeCalledWith(
+					expect.objectContaining({
+						formatted24: '0:20',
+					}),
+				)
+
+				// toggle pm
+				changeMeridiem(wrapper)
+				fireEvent.click(getByTestId('topbar_hour'))
+				const numbersPM = getAllByTestId('time-dropdown_number')
+
+				onChange.mockClear()
+				fireEvent.click(numbersPM[0]) // click 1
+				fireEvent.click(numbersPM[3]) // click 4
+				fireEvent.click(numbersPM[11]) // click 12
+				expect(onChange).not.toBeCalled()
+				fireEvent.click(numbersPM[4]) // click 4
+				expect(onChange).toBeCalledWith(
+					expect.objectContaining({
+						formatted24: '17:20',
+					}),
+				)
+
+				// test minutes
+				fireEvent.click(getByTestId('topbar_minute'))
+				fireEvent.click(getByTestId('topbar_minute'))
+
+				onChange.mockClear()
+				const numbersMin = getAllByTestId('time-dropdown_number')
+				fireEvent.click(numbersMin[0])
+				fireEvent.click(numbersMin[34])
+				expect(onChange).not.toBeCalled()
+				fireEvent.click(numbersMin[35])
+				expect(onChange).toBeCalledWith(
+					expect.objectContaining({
+						formatted24: '17:35',
+					}),
+				)
+			})
+
+			it('handles blocked off times during 24h mode', () => {
+				const { onChange, numbers, wrapper } = renderHourDropdown({
+					time: { hour: 5, minute: 20 },
+					hour24Mode: true,
+					disabledTimeRange: { from: '17:20', to: '6:35' },
+				})
+				const { getByTestId, getAllByTestId } = wrapper
+
+				fireEvent.click(numbers[0]) // click 1
+				fireEvent.click(numbers[4]) // click 5
+				fireEvent.click(numbers[17]) // click 18
+				fireEvent.click(numbers[23]) // click 24/00
+				expect(onChange).not.toBeCalled()
+				fireEvent.click(numbers[16])
+				expect(onChange).toBeCalledWith(
+					expect.objectContaining({
+						formatted24: '17:20',
+					}),
+				)
+
+				// test minutes
+				fireEvent.click(getByTestId('topbar_minute'))
+				fireEvent.click(getByTestId('topbar_minute'))
+
+				onChange.mockClear()
+				const numbersMin = getAllByTestId('time-dropdown_number')
+				fireEvent.click(numbersMin[21])
+				fireEvent.click(numbersMin[22])
+				fireEvent.click(numbersMin[59])
+				expect(onChange).not.toBeCalled()
+				fireEvent.click(numbersMin[20])
+				expect(onChange).toBeCalledWith(
+					expect.objectContaining({
+						formatted24: '17:20',
+					}),
+				)
+			})
 		})
 	})
 })

--- a/src/components/__tests__/events.test.tsx
+++ b/src/components/__tests__/events.test.tsx
@@ -36,7 +36,7 @@ describe('handles events correctly', () => {
 
 			clickOnPoint(wrapper, coords)
 
-			expect(onChange).toBeCalledTimes(1)
+			expect(onChange).toBeCalledTimes(2)
 			expect(onChange).toBeCalledWith(
 				expect.objectContaining({
 					formatted24: expectedTime,
@@ -105,7 +105,7 @@ describe('handles events correctly', () => {
 
 			clickOnPoint(wrapper, coords)
 
-			expect(onChange).toBeCalledTimes(1)
+			expect(onChange).toBeCalledTimes(2)
 			expect(onChange).toBeCalledWith(
 				expect.objectContaining({
 					formatted24: expectedTime,

--- a/src/components/__tests__/helpers/coords.ts
+++ b/src/components/__tests__/helpers/coords.ts
@@ -50,3 +50,21 @@ export const MINUTE_59: Coords = {
 	clientX: CLOCK_RADIUS - 2,
 	clientY: 1,
 }
+
+// for testing midnight/noon angles
+export const MIDNIGHT_OUTER_FROM_LEFT: Coords = {
+	clientX: CLOCK_RADIUS - 1,
+	clientY: 1,
+}
+export const MIDNIGHT_OUTER_FROM_RIGHT: Coords = {
+	clientX: CLOCK_RADIUS + 1,
+	clientY: 1,
+}
+export const MIDNIGHT_INNER_FROM_LEFT: Coords = {
+	clientX: CLOCK_RADIUS - 1,
+	clientY: CLOCK_RADIUS - 25,
+}
+export const MIDNIGHT_INNER_FROM_RIGHT: Coords = {
+	clientX: CLOCK_RADIUS + 1,
+	clientY: CLOCK_RADIUS - 25,
+}

--- a/src/components/__tests__/helpers/coords.ts
+++ b/src/components/__tests__/helpers/coords.ts
@@ -1,8 +1,26 @@
-import { CLOCK_RADIUS } from '../../../helpers/constants'
+import { rad } from '../../../helpers/math'
+import { CLOCK_RADIUS, INNER_NUMBER_RADIUS } from '../../../helpers/constants'
 
 export interface Coords {
 	clientX?: number
 	clientY?: number
+}
+
+// val is 1-60
+export function generateCoords(val: number, unit: 'hour' | 'minute'): Coords {
+	const angle = unit === 'minute' ? val * 6 : (val % 12) * 30
+
+	const isInner = unit === 'hour' && val <= 12 && val !== 0
+
+	// -1 to ensure it's within radius
+	const radius = isInner ? INNER_NUMBER_RADIUS - 1 : CLOCK_RADIUS - 1
+
+	const x = radius * Math.sin(rad(angle))
+	const y = radius * Math.cos(rad(angle))
+	return {
+		clientX: x + CLOCK_RADIUS,
+		clientY: Math.abs(y - CLOCK_RADIUS),
+	}
 }
 
 /*
@@ -12,11 +30,7 @@ export interface Coords {
 		y = clock_radius
 */
 
-/*
-	TODO - make function to convert minutes/hours to coords
-	otherwise changing CLOCK_RADIUS will end up breaking coords
-*/
-
+// TODO - deprecate coords below for fn above
 export const HOUR_3_OUTER: Coords = {
 	clientX: CLOCK_RADIUS * 2 - 1,
 	clientY: CLOCK_RADIUS,

--- a/src/components/__tests__/helpers/dom.tsx
+++ b/src/components/__tests__/helpers/dom.tsx
@@ -29,6 +29,12 @@ export function changeToMinutes(wrapper: RenderResult) {
 	})
 }
 
+export function changeMeridiem(wrapper: RenderResult, meridiem = 'pm') {
+	fireEvent.click(
+		wrapper.getByTestId(meridiem === 'pm' ? 'meridiem_pm' : 'meridiem_am'),
+	)
+}
+
 export function clickOnPoint(wrapper: RenderResult, coords: Coords) {
 	const { getByTestId } = wrapper
 	const cw = getByTestId('clock-wrapper')

--- a/src/components/__tests__/helpers/dom.tsx
+++ b/src/components/__tests__/helpers/dom.tsx
@@ -34,7 +34,13 @@ export function clickOnPoint(wrapper: RenderResult, coords: Coords) {
 	const cw = getByTestId('clock-wrapper')
 
 	// trigger mousedown and them up with coordinates
-	fireEvent.mouseDown(cw)
+	fireEvent(
+		cw,
+		new MouseEvent('mousedown', {
+			...coords,
+			bubbles: true,
+		}),
+	)
 	fireEvent(
 		cw,
 		new MouseEvent('mouseup', {

--- a/src/components/styles/numbers.ts
+++ b/src/components/styles/numbers.ts
@@ -7,6 +7,7 @@ import {
 } from '../../helpers/constants'
 
 const CLOCK_NUMBER_COLOR = '#999999'
+const CLOCK_NUMBER_COLOR_DISABLED = '#ddd'
 
 function getFontSize(hour24Mode: boolean, inner: boolean): string {
 	if (!hour24Mode) {
@@ -20,12 +21,21 @@ function getFontSize(hour24Mode: boolean, inner: boolean): string {
 interface Props {
 	hour24Mode?: boolean
 	inner?: boolean
+	enabled?: boolean
 }
 
-export const numbersStyle = ({ hour24Mode = false, inner = false }: Props) => css`
+const enabledColor = `var(--numbers-text-color, ${CLOCK_NUMBER_COLOR})`
+const disabledColor = `var(--numbers-text-color-disabled, ${CLOCK_NUMBER_COLOR_DISABLED})`
+
+export const numbersStyle = ({
+	hour24Mode = false,
+	inner = false,
+	enabled = true,
+}: Props) => css`
 	display: inline-block;
 	position: absolute;
-	color: var(--numbers-text-color, ${CLOCK_NUMBER_COLOR});
+	color: ${enabled ? enabledColor : disabledColor};
+	transition: color 0.15s ease-out;
 	pointer-events: none;
 	border-radius: 99px;
 	width: ${NUMBER_RADIUS_REGULAR}px;

--- a/src/components/styles/time-dropdown.ts
+++ b/src/components/styles/time-dropdown.ts
@@ -4,6 +4,7 @@ import { MODE } from '../../helpers/constants'
 
 const DROPDOWN_BORDER = '#f4f4f4'
 const DROPDOWN_COLOR = '#8c8c8c'
+const DROPDOWN_COLOR_DISABLED = '#ddd'
 const DROPDOWN_SELECTED_COLOR = '#EAF8FF'
 
 const hour = `right: -22px;`
@@ -48,14 +49,23 @@ export const options = css`
 `
 
 const selected = `background: ${DROPDOWN_SELECTED_COLOR};`
-export const option = (active: boolean) => css`
+
+interface OptionStyleProps {
+	active: boolean
+	enabled: boolean
+}
+
+const enabledColor = `var(--dropdown-text-color, ${DROPDOWN_COLOR})`
+const disabledColor = `var(--dropdown-text-color-disabled, ${DROPDOWN_COLOR_DISABLED})`
+
+export const option = ({ active, enabled }: OptionStyleProps) => css`
 	background: transparent;
 	padding: 7px 30px;
 	font-size: 16px;
-	color: var(--dropdown-text-color, ${DROPDOWN_COLOR});
-	cursor: pointer;
+	color: ${enabled ? enabledColor : disabledColor};
+	cursor: ${enabled ? 'pointer' : 'not-allowed'};
 	&:hover {
-		background: var(--dropdown-hover-bg, ${DROPDOWN_SELECTED_COLOR});
+		background: ${enabled && `var(--dropdown-hover-bg, ${DROPDOWN_SELECTED_COLOR})`};
 	}
 	${active && selected}
 `

--- a/src/helpers/__tests__/disable-time.test.ts
+++ b/src/helpers/__tests__/disable-time.test.ts
@@ -20,6 +20,7 @@ const hourTestCases: HourTestCase[] = [
 		from: '6:00',
 		to: '15:00',
 		cases: [
+			[0, true],
 			[4, true],
 			[6, true],
 			[7, false],

--- a/src/helpers/__tests__/disable-time.test.ts
+++ b/src/helpers/__tests__/disable-time.test.ts
@@ -1,0 +1,219 @@
+import DisabledTimeRange from '../disable-time'
+
+interface HourTestCase {
+	name: string
+	from: string
+	to: string
+	cases: [hour: number, expected: boolean][]
+}
+
+interface MinuteTestCase extends Omit<HourTestCase, 'cases'> {
+	name: string
+	from: string
+	to: string
+	cases: [hour: number, minute: number, expected: boolean][]
+}
+
+const hourTestCases: HourTestCase[] = [
+	{
+		name: 'basic time range',
+		from: '6:00',
+		to: '15:00',
+		cases: [
+			[4, true],
+			[6, true],
+			[7, false],
+			[14, false],
+			[15, true],
+			[16, true],
+		],
+	},
+	{
+		name: 'basic time range with minutes',
+		from: '6:20',
+		to: '15:35',
+		cases: [
+			[4, true],
+			[6, true],
+			[7, false],
+			[14, false],
+			[15, true],
+			[16, true],
+		],
+	},
+	{
+		name: 'overnight time range',
+		from: '15:00',
+		to: '6:00',
+		cases: [
+			[4, false],
+			[6, true],
+			[7, true],
+			[14, true],
+			[15, true],
+			[16, false],
+		],
+	},
+	{
+		name: 'overnight time range with minutes',
+		from: '15:20',
+		to: '6:35',
+		cases: [
+			[4, false],
+			[6, true],
+			[7, true],
+			[14, true],
+			[15, true],
+			[16, false],
+		],
+	},
+	{
+		name: 'same hour, regular range',
+		from: '6:20',
+		to: '6:45',
+		cases: [
+			[2, true],
+			[5, true],
+			[6, true],
+			[7, true],
+			[10, true],
+		],
+	},
+	{
+		name: 'same hour, overnight',
+		from: '6:45',
+		to: '6:20',
+		cases: [
+			[2, false],
+			[5, false],
+			[6, true],
+			[7, false],
+			[10, false],
+		],
+	},
+	{
+		name: 'same hour, on the hour',
+		from: '6:00',
+		to: '6:20',
+		cases: [
+			[2, true],
+			[5, true],
+			[6, true],
+			[7, true],
+			[10, true],
+		],
+	},
+	{
+		name: 'midnight, regular range',
+		from: '0:20',
+		to: '6:20',
+		cases: [
+			[0, true],
+			[1, false],
+			[5, false],
+			[6, true],
+			[7, true],
+			[10, true],
+		],
+	},
+	{
+		name: 'midnight, on the hour, regular range',
+		from: '0:00',
+		to: '6:20',
+		cases: [
+			[0, true],
+			[1, false],
+			[5, false],
+			[6, true],
+			[7, true],
+			[10, true],
+		],
+	},
+	{
+		name: 'midnight, overnight',
+		from: '20:00',
+		to: '0:00',
+		cases: [
+			[0, true],
+			[1, true],
+			[19, true],
+			[20, true],
+			[24, false],
+		],
+	},
+]
+
+const MinuteTestCase: MinuteTestCase[] = [
+	{
+		name: 'basic time range, on the hour',
+		from: '6:00',
+		to: '15:00',
+		cases: [
+			[5, 59, true],
+			[6, 0, true],
+			[7, 5, false],
+			[15, 0, true],
+			[15, 5, true],
+		],
+	},
+	{
+		name: 'basic time range',
+		from: '6:20',
+		to: '15:35',
+		cases: [
+			[5, 59, true],
+			[6, 19, true],
+			[6, 20, true],
+			[6, 21, false],
+			[7, 5, false],
+			[15, 0, false],
+			[15, 5, false],
+			[15, 34, false],
+			[15, 35, true],
+			[15, 36, true],
+		],
+	},
+	{
+		name: 'overnight time range',
+		from: '15:35',
+		to: '6:20',
+		cases: [
+			[14, 34, true],
+			[15, 34, true],
+			[15, 35, true],
+			[15, 36, false],
+			[16, 19, false],
+			[5, 0, false],
+			[6, 0, false],
+			[6, 19, false],
+			[6, 20, true],
+			[6, 21, true],
+		],
+	},
+]
+
+describe('disabled time range - hours', () => {
+	hourTestCases.forEach(({ name, from, to, cases }) => {
+		describe(`${name}: ${from} -> ${to}`, () => {
+			const dtr = new DisabledTimeRange(from, to)
+			cases.forEach(([hour, expected]) => {
+				it(`hour: ${hour} -> ${expected}`, () => {
+					expect(dtr.validateHour(hour)).toEqual(expected)
+				})
+			})
+		})
+	})
+})
+
+describe('disabled time range - minutes', () => {
+	MinuteTestCase.forEach(({ name, from, to, cases }) => {
+		describe(`${name}: ${from} -> ${to}`, () => {
+			const dtr = new DisabledTimeRange(from, to)
+			cases.forEach(([hour, minute, expected]) => {
+				it(`hour: ${hour}, minute: ${minute} -> ${expected}`, () => {
+					expect(dtr.validateMinute(hour, minute)).toEqual(expected)
+				})
+			})
+		})
+	})
+})

--- a/src/helpers/disable-time.ts
+++ b/src/helpers/disable-time.ts
@@ -16,8 +16,6 @@ function parseTime(time: string) {
 	}
 }
 
-// TODO - account for 24 and 0 ranges
-// DONE - account for same
 function generateHourValidator(
 	fromH: number,
 	fromM: number,
@@ -33,7 +31,7 @@ function generateHourValidator(
 		return hour => hour <= minH || hour >= maxH
 	}
 
-	// overnight range - fromH > toH || (isSameHour && fromM > toM)
+	// overnight range: fromH > toH || (isSameHour && fromM > toM)
 	return hour => hour <= minH && hour >= maxH
 }
 

--- a/src/helpers/disable-time.ts
+++ b/src/helpers/disable-time.ts
@@ -1,0 +1,82 @@
+import { TIME_PARSE_24 } from './time'
+
+/*
+	module assumes 24h format
+*/
+
+function parseTime(time: string) {
+	const match = time.match(TIME_PARSE_24)
+	if (!match) {
+		throw new Error('Could not parse time for disabled time range')
+	}
+
+	return {
+		hour: parseInt(match[1], 10),
+		minute: parseInt(match[2], 10),
+	}
+}
+
+// TODO - account for 24 and 0 ranges
+// DONE - account for same
+function generateHourValidator(
+	fromH: number,
+	fromM: number,
+	toH: number,
+	toM: number,
+): (hour: number) => boolean {
+	const minH = fromH
+	const maxH = toH
+	const isSameHour = fromH === toH
+
+	if (fromH < toH || (isSameHour && fromM < toM)) {
+		// regular range
+		return hour => hour <= minH || hour >= maxH
+	}
+
+	// overnight range - fromH > toH || (isSameHour && fromM > toM)
+	return hour => hour <= minH && hour >= maxH
+}
+
+function generateMinuteValidator(
+	fromH: number,
+	fromM: number,
+	toH: number,
+	toM: number,
+	hourValidator: (hour: number) => boolean,
+): (hour: number, minute: number) => boolean {
+	return (h, m) => {
+		// if hour is invalid, all minutes should be invalid
+		if (!hourValidator(h)) {
+			return false
+		}
+		if (h === fromH) {
+			return m <= fromM
+		} else if (h === toH) {
+			return m >= toM
+		}
+		return true
+	}
+}
+
+export default class DisabledTimeRange {
+	constructor(from: string, to: string) {
+		const { hour: fromH, minute: fromM } = parseTime(from)
+		const { hour: toH, minute: toM } = parseTime(to)
+
+		if (fromH === toH && fromM === toM) {
+			throw new Error('invalid date range - same time')
+		}
+
+		this.validateHour = generateHourValidator(fromH, fromM, toH, toM)
+		this.validateMinute = generateMinuteValidator(
+			fromH,
+			fromM,
+			toH,
+			toM,
+			this.validateHour,
+		)
+	}
+
+	validateHour: (hour: number) => boolean
+	validateMinute: (hour: number, minute: number) => boolean
+}

--- a/src/helpers/dom.ts
+++ b/src/helpers/dom.ts
@@ -12,7 +12,10 @@ export type CalcOffsetFn = (x: number, y: number) => { offsetX: number; offsetY:
 export function calcOffset(el: HTMLDivElement): CalcOffsetFn {
 	const style = window.getComputedStyle(el, null)
 
-	return function(clientX: number, clientY: number): { offsetX: number; offsetY: number } {
+	return function (
+		clientX: number,
+		clientY: number,
+	): { offsetX: number; offsetY: number } {
 		const borderLeftWidth = parseInt(style.borderLeftWidth!, 10) || 0
 		const borderTopWidth = parseInt(style.borderTopWidth!, 10) || 0
 		const rect = el.getBoundingClientRect()

--- a/src/helpers/math.ts
+++ b/src/helpers/math.ts
@@ -9,7 +9,7 @@ const pi = Math.PI
 
 const ANGLE_PER_INCREMENT = 360 / VISIBLE_NUMBERS_PER_CIRCLE
 
-function rad(deg: number): number {
+export function rad(deg: number): number {
 	return deg / (180 / pi)
 }
 export function deg(rad: number): number {

--- a/src/helpers/math.ts
+++ b/src/helpers/math.ts
@@ -1,4 +1,8 @@
-import { VISIBLE_NUMBERS_PER_CIRCLE, CLOCK_RADIUS, NUMBER_RADIUS_REGULAR } from './constants'
+import {
+	VISIBLE_NUMBERS_PER_CIRCLE,
+	CLOCK_RADIUS,
+	NUMBER_RADIUS_REGULAR,
+} from './constants'
 
 const { cos, sin } = Math
 const pi = Math.PI
@@ -39,14 +43,6 @@ export function transform(index: number, t: number): string {
 export function isWithinRadius(x: number, y: number, radius: number): boolean {
 	return Math.sqrt(x * x + y * y) < radius
 }
-
-export type CalcTimeFromAngle = (
-	angle: number,
-	{
-		canAutoChangeUnit,
-		wasTapped,
-	}: { canAutoChangeUnit: boolean; wasTapped: boolean; isInnerClick: boolean },
-) => void
 
 // normalize any angles to 0-360 deg
 function normalize(angle: number): number {

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -1,7 +1,7 @@
 import { Time, TimeInput, TimeOutput } from './types'
 
 const TIME_PARSE_MERIDIEM = new RegExp(/^(\d{1,2}?):(\d{2}?)\s?(am|pm)$/i)
-const TIME_PARSE_24 = new RegExp(/^(\d{1,2}?):(\d{2}?)$/)
+export const TIME_PARSE_24 = new RegExp(/^(\d{1,2}?):(\d{2}?)$/)
 
 const defaultTime = {
 	hour: 12,
@@ -104,8 +104,8 @@ export function composeTime(hour: number, minute: number): TimeOutput {
 		formatted12: `${hour12}:${paddedMinute} ${meridiem}`,
 		formattedSimple: `${hour12}:${paddedMinute}`,
 		hour: hour24,
-		hour12: hour12,
-		minute: minute,
-		meridiem: meridiem,
+		hour12,
+		minute,
+		meridiem,
 	}
 }

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -1,3 +1,4 @@
+import DisabledTimeRange from './disable-time'
 import { Time, TimeInput, TimeOutput } from './types'
 
 const TIME_PARSE_MERIDIEM = new RegExp(/^(\d{1,2}?):(\d{2}?)\s?(am|pm)$/i)
@@ -87,7 +88,11 @@ export function parseMeridiem(time: TimeInput): string {
 }
 
 // formats time output to poss to parent
-export function composeTime(hour: number, minute: number): TimeOutput {
+export function composeTime(
+	hour: number,
+	minute: number,
+	disabledTimeRangeValidator: DisabledTimeRange | null,
+): TimeOutput {
 	const paddedMinute = ('0' + minute).slice(-2)
 	const hour24 = hour === 24 ? 0 : hour
 
@@ -99,6 +104,16 @@ export function composeTime(hour: number, minute: number): TimeOutput {
 		hour12 = hour = 12
 	}
 
+	let isValid = true
+	if (disabledTimeRangeValidator) {
+		if (
+			!disabledTimeRangeValidator.validateHour(hour24) ||
+			!disabledTimeRangeValidator.validateMinute(hour24, minute)
+		) {
+			isValid = false
+		}
+	}
+
 	return {
 		formatted24: `${hour24}:${paddedMinute}`,
 		formatted12: `${hour12}:${paddedMinute} ${meridiem}`,
@@ -107,5 +122,6 @@ export function composeTime(hour: number, minute: number): TimeOutput {
 		hour12,
 		minute,
 		meridiem,
+		isValid,
 	}
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -32,4 +32,5 @@ export interface TimeOutput {
 	hour12: number
 	minute: number
 	meridiem: string
+	isValid: boolean
 }

--- a/src/hooks/useClockEvents.ts
+++ b/src/hooks/useClockEvents.ts
@@ -37,15 +37,21 @@ export default function useClockEvents(
 		}
 		dragCount.current = 0
 
+		// terminate if click is outside of clock radius, ie:
+		// if clicking meridiem button which overlaps with clock
+		if (clock.current) {
+			calcOffsetCache.current = calcOffset(clock.current)
+			const { offsetX, offsetY } = calcOffsetCache.current!(e.clientX, e.clientY)
+			const x = offsetX - CLOCK_RADIUS
+			const y = offsetY - CLOCK_RADIUS
+			if (!isWithinRadius(x, y, CLOCK_RADIUS)) return
+		}
+
 		// add listeners
 		document.addEventListener('mousemove', handleMouseDrag, false)
 		document.addEventListener('mouseup', handleStopDrag, false)
 		wrapper.current &&
 			wrapper.current.addEventListener('mouseleave', handleStopDrag, false)
-
-		if (clock.current) {
-			calcOffsetCache.current = calcOffset(clock.current)
-		}
 
 		// @ts-ignore
 		handleMouseDrag(e)

--- a/src/hooks/useClockEvents.ts
+++ b/src/hooks/useClockEvents.ts
@@ -47,7 +47,6 @@ export default function useClockEvents(
 			calcOffsetCache.current = calcOffset(clock.current)
 		}
 
-		// move hand
 		// @ts-ignore
 		handleMouseDrag(e)
 	}

--- a/src/hooks/useClockEvents.ts
+++ b/src/hooks/useClockEvents.ts
@@ -10,9 +10,9 @@ const { atan2 } = Math
 type CalcTimeFromAngle = (
 	angle: number,
 	{
-		canAutoChangeUnit,
+		canAutoChangeMode,
 		wasTapped,
-	}: { canAutoChangeUnit: boolean; wasTapped: boolean; isInnerClick: boolean },
+	}: { canAutoChangeMode: boolean; wasTapped: boolean; isInnerClick: boolean },
 ) => void
 
 /*
@@ -159,7 +159,7 @@ export default function useClockEvents(
 		// determines if change is due to mouseup/touchend in order to
 		// automatically change unit (eg: hour -> minute) if enabled
 		// prevents changing unit if dragging along clock
-		canAutoChangeUnit: boolean,
+		canAutoChangeMode: boolean,
 	) {
 		// if user just clicks/taps a number (drag count < 2), then just assume it's a rough tap
 		// and force a rounded/coarse number (ie: 1, 2, 3, 4 is tapped, assume 0 or 5)
@@ -181,7 +181,7 @@ export default function useClockEvents(
 		const isInnerClick = isWithinRadius(x, y, INNER_NUMBER_RADIUS)
 
 		// update time on main
-		handleChange(d, { canAutoChangeUnit, wasTapped, isInnerClick })
+		handleChange(d, { canAutoChangeMode, wasTapped, isInnerClick })
 	}
 
 	// clean up

--- a/src/hooks/useStateContext.tsx
+++ b/src/hooks/useStateContext.tsx
@@ -215,17 +215,19 @@ export function StateProvider({
 				val += 12
 			}
 
-			handleUpdateTimeSideEffects(source)
-
 			const unit = isHourMode(mode) ? 'hour' : 'minute'
 			const time = refTime.current
 
-			// useful for same value when dragging between degrees in hours
-			if (time[unit] === val) {
+			// perf to avoid unecessary updates when dragging on clock
+			if (
+				time[unit] === val &&
+				source.type === 'clock' &&
+				!source.canAutoChangeMode
+			) {
 				return
 			}
 
-			//
+			// if time is blocked off, dont update
 			if (disabledTimeRangeValidator) {
 				if (
 					(isHourMode(mode) && !disabledTimeRangeValidator.validateHour(val)) ||
@@ -235,6 +237,8 @@ export function StateProvider({
 					return
 				}
 			}
+
+			handleUpdateTimeSideEffects(source)
 
 			// generate new time and update timekeeper state
 			const newTime: Time = { ...time, [unit]: val }

--- a/src/hooks/useStateContext.tsx
+++ b/src/hooks/useStateContext.tsx
@@ -126,8 +126,8 @@ export function StateProvider({
 
 	const getComposedTime = useCallback(() => {
 		const time = refTime.current
-		return composeTime(time.hour, time.minute)
-	}, [])
+		return composeTime(time.hour, time.minute, disabledTimeRangeValidator)
+	}, [disabledTimeRangeValidator])
 
 	// debounced onChange function from parent
 	const debounceUpdateParent = useMemo(() => {


### PR DESCRIPTION
PR includes:
- memoize several update time state management functions
- constrains mouse down to clock circle - fixes https://github.com/catc/react-timekeeper/issues/73
- adds support for the `disabledTimeRange` feature - closes #29 and #63

<img width="335" alt="Screen Shot 2021-12-27 at 11 38 03 PM" src="https://user-images.githubusercontent.com/5651132/147540982-86d6aa05-0798-424c-a803-2bb305a981fe.png">
